### PR TITLE
Fix duplicate fields and buttons in the inspector when using inheritance

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/ReflectionHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/ReflectionHelper.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using UnityEngine;
 
 namespace Alchemy.Editor.Internal
 {
@@ -125,10 +126,33 @@ namespace Alchemy.Editor.Internal
             return info;
         }
 
+        static IEnumerable<Type> EnumerateTypeHierarchy(Type type)
+        {
+            while (type != null)
+            {
+                yield return type;
+                type = type.BaseType;
+            }
+        }
+
+        class FieldInfoEqualityComparer : IEqualityComparer<FieldInfo>
+        {
+            public static readonly FieldInfoEqualityComparer Instance = new();
+
+            public bool Equals(FieldInfo x, FieldInfo y)
+            {
+                return x.Name == y.Name && x.DeclaringType == y.DeclaringType;
+            }
+
+            public int GetHashCode(FieldInfo obj)
+            {
+                return HashCode.Combine(obj.Name, obj.DeclaringType);
+            }
+        }
+
         static IEnumerable<FieldInfo> GetAllFieldsIncludingBaseNonPublic(Type type, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
         {
-            if (type == null) return Enumerable.Empty<FieldInfo>();
-            return type.GetFields(bindingAttr).Concat(GetAllFieldsIncludingBaseNonPublic(type.BaseType));
+            return EnumerateTypeHierarchy(type).Reverse().SelectMany(t => t.GetFields(bindingAttr)).Distinct(FieldInfoEqualityComparer.Instance);
         }
 
         public static PropertyInfo GetProperty(Type type, string name, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static, bool includingBaseNonPublic = false)
@@ -148,10 +172,24 @@ namespace Alchemy.Editor.Internal
             return info;
         }
 
+        class PropertyInfoEqualityComparer : IEqualityComparer<PropertyInfo>
+        {
+            public static readonly PropertyInfoEqualityComparer Instance = new();
+
+            public bool Equals(PropertyInfo x, PropertyInfo y)
+            {
+                return x.Name == y.Name && x.DeclaringType == y.DeclaringType;
+            }
+
+            public int GetHashCode(PropertyInfo obj)
+            {
+                return HashCode.Combine(obj.Name, obj.DeclaringType);
+            }
+        }
+
         static IEnumerable<PropertyInfo> GetAllPropertiesIncludingBaseNonPublic(Type type, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
         {
-            if (type == null) return Enumerable.Empty<PropertyInfo>();
-            return type.GetProperties(bindingAttr).Concat(GetAllPropertiesIncludingBaseNonPublic(type.BaseType));
+            return EnumerateTypeHierarchy(type).Reverse().SelectMany(t => t.GetProperties(bindingAttr)).Distinct(PropertyInfoEqualityComparer.Instance);
         }
 
         public static MethodInfo GetMethod(Type type, string name, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static, bool includingBaseNonPublic = false)
@@ -171,10 +209,24 @@ namespace Alchemy.Editor.Internal
             return info;
         }
 
+        class MethodInfoEqualityComparer : IEqualityComparer<MethodInfo>
+        {
+            public static readonly MethodInfoEqualityComparer Instance = new();
+
+            public bool Equals(MethodInfo x, MethodInfo y)
+            {
+                return x.Name == y.Name && x.DeclaringType == y.DeclaringType;
+            }
+
+            public int GetHashCode(MethodInfo obj)
+            {
+                return HashCode.Combine(obj.Name, obj.DeclaringType);
+            }
+        }
+
         static IEnumerable<MethodInfo> GetAllMethodsIncludingBaseNonPublic(Type type, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
         {
-            if (type == null) return Enumerable.Empty<MethodInfo>();
-            return type.GetMethods(bindingAttr).Concat(GetAllMethodsIncludingBaseNonPublic(type.BaseType));
+            return EnumerateTypeHierarchy(type).Reverse().SelectMany(t => t.GetMethods(bindingAttr)).Distinct(MethodInfoEqualityComparer.Instance);
         }
 
         public static object GetValue(object target, string name, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static, bool allowProperty = true, bool allowMethod = true)
@@ -247,10 +299,24 @@ namespace Alchemy.Editor.Internal
             }
         }
 
+        class MemberInfoEqualityComparer : IEqualityComparer<MemberInfo>
+        {
+            public static readonly MemberInfoEqualityComparer Instance = new();
+
+            public bool Equals(MemberInfo x, MemberInfo y)
+            {
+                return x.Name == y.Name && x.DeclaringType == y.DeclaringType;
+            }
+
+            public int GetHashCode(MemberInfo obj)
+            {
+                return HashCode.Combine(obj.Name, obj.DeclaringType);
+            }
+        }
+
         static IEnumerable<MemberInfo> GetMembersIncludingBaseNonPublic(Type type, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
         {
-            if (type == null) return Enumerable.Empty<MemberInfo>();
-            return type.GetMembers(bindingAttr).Concat(GetMembersIncludingBaseNonPublic(type.BaseType));
+            return EnumerateTypeHierarchy(type).Reverse().SelectMany(t => t.GetMembers(bindingAttr)).Distinct(MemberInfoEqualityComparer.Instance);
         }
 
         public static object Invoke(object target, string name, params object[] parameters)


### PR DESCRIPTION
The following pull request provides a solution to the issue of duplicated fields in the inspector when using inheritance (#15 and partially #12). The cause of the problem is the concatenation of the members of the current type and its base types.

## Solution

The proposed solution is to use `Distinct` to remove duplicates, using both `MemberInfo.Name` and `MemberInfo.DeclaringType` as the equality check:

```csharp
class MemberInfoEqualityComparer : IEqualityComparer<MemberInfo>
{
    public static MemberInfoEqualityComparer Instance { get; } = new();

    public bool Equals(MemberInfo x, MemberInfo y)
    {
        return x.Name == y.Name && x.DeclaringType == y.DeclaringType;
    }

    public int GetHashCode(MemberInfo obj)
    {
        return HashCode.Combine(obj.Name, obj.DeclaringType);
    }
}

static IEnumerable<MemberInfo> GetMembersIncludingBaseNonPublic(Type type, BindingFlags bindingAttr = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
{
    return EnumerateTypeHierarchy(type)
        .Reverse()
        .SelectMany(t => t.GetMembers(bindingAttr))
        .Distinct(MemberInfoEqualityComparer.Instance);
}
```

The same logic was applied to `GetAllFieldsIncludingBaseNonPublic`, `GetAllPropertiesIncludingBaseNonPublic` and `GetAllMethodsIncludingBaseNonPublic`.

I've decided to use `Reverse` operator too, to order the fields from the base types first, then the fields from the current type - same as the default Unity inspector does.

## Tests

Recreated the example from https://github.com/AnnulusGames/Alchemy/issues/13, adding private methods of same name too:

```csharp
// file: A.cs
public class A : MonoBehaviour
{
    public string aPublic;
    [SerializeField] protected string aProtected;
    [SerializeField] private string aPrivate;

    [Button] public void TestA() => Debug.Log($"Test from {nameof(A)}");
    [Button] private void TestPrivate() => Debug.Log($"Test from {nameof(A)}");
}

// file: B.cs
public class B : A
{
    public string bPublic;
    [SerializeField] protected string bProtected;
    [SerializeField] private string bPrivate;

    [Button] public void TestB() => Debug.Log($"Test from {nameof(B)}");
    [Button] private void TestPrivate() => Debug.Log($"Test from {nameof(B)}");
}

// file: C.cs
public class C : B
{
    public string cPublic;
    [SerializeField] protected string cProtected;
    [SerializeField] private string cPrivate;

    [Button] public void TestC() => Debug.Log($"Test from {nameof(C)}");
    [Button] private void TestPrivate() => Debug.Log($"Test from {nameof(C)}");
}
```

Inspector of a `C` instance:

![C Inspector](https://github.com/AnnulusGames/Alchemy/assets/94767801/d0002037-efe2-44fc-b456-720d84696fcf)

---

#15 seems to be caused by two different issues, as its still not fixed. The following script:

```csharp
public class ExampleBehaviour : MonoBehaviour
{
    [SerializeField] private new Rigidbody rigidbody;
    [field: SerializeField] public Transform camera { get; private set; }
    public float light;
}
```

...still isn't displayed correctly in the inspector (compare to the example in the issue): 

![ExampleBehaviour Inspector](https://github.com/AnnulusGames/Alchemy/assets/94767801/33485c49-e31a-41dc-ba55-9de118941a30)

I'll update the issue, if the pull request is accepted.

## Other solutions considered

- Replacing `Concat` in the original implementation with `Union`, leaving the `GetAll...IncludingBaseNonPublic` recursive. This would cause the `Union` to be evaluated for each level of the hierarchy, resulting in redundant equality checks.
- Using `Type.Name` alone as the equality check. This would affect types that hide inherited members or redeclare private members of base types, returning only the member *closest* to the current type. Same goes for methods - only the *closest* method to the current type would get a button when using `ButtonAttribute`. In the example above, only `A.TestPrivate` would be visible in the inspector of a `C` instance.