### PR TITLE
Fix: TypeHelper.GetDefaultValue and CreateDefaultInstance don't work …

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/TypeHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/TypeHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Alchemy.Editor
 {
@@ -13,14 +14,14 @@ namespace Alchemy.Editor
                 return null;
             }
 
-            return Activator.CreateInstance(type);
+            return FormatterServices.GetUninitializedObject(type);
         }
 
         public static object CreateDefaultInstance(Type type)
         {
             if (type == typeof(string)) return "";
             if (type.IsSubclassOf(typeof(UnityEngine.Object))) return null;
-            return Activator.CreateInstance(type);
+            return FormatterServices.GetUninitializedObject(type);
         }
 
         public static IEnumerable<Type> GetBaseClassesAndInterfaces(Type type, bool includeSelf = false)


### PR DESCRIPTION
…in the class which has no constructor without parameters.

```cs
[Serializable]
public class MyClass
{
    public int Value;
  
    public MyClass(int value)
    {
        Value = value;
    }
}
[AlchemySerializeField]
Dictionary<string,MyClass> myClassDictionary;
```