### PR TITLE
Fix: support 2021.3 & 2022.1

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
@@ -127,7 +127,7 @@ namespace Alchemy.Editor.Elements
             else if (type == typeof(ulong))
             {
 #if UNITY_2022_2_OR_NEWER
-                AddField(new UnsignedIntegerField(label), (ulong)obj);
+                AddField(new UnsignedLongField(label), (ulong)obj);
 #else
                 var value = (ulong)obj;
                 var control = new LongField(label);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
@@ -103,7 +103,7 @@ namespace Alchemy.Editor.Elements
             
             else if (type == typeof(uint))
             {
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_1_OR_NEWER
                 AddField(new UnsignedIntegerField(label), (uint)obj);
 #else
                 var value = (uint)obj;
@@ -126,7 +126,7 @@ namespace Alchemy.Editor.Elements
             }
             else if (type == typeof(ulong))
             {
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_1_OR_NEWER
                 AddField(new UnsignedLongField(label), (ulong)obj);
 #else
                 var value = (ulong)obj;

--- a/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
@@ -100,9 +100,25 @@ namespace Alchemy.Editor.Elements
             {
                 AddField(new IntegerField(label), (int)obj);
             }
+            
             else if (type == typeof(uint))
             {
+#if UNITY_2022_2_OR_NEWER
                 AddField(new UnsignedIntegerField(label), (uint)obj);
+#else
+                var value = (uint)obj;
+                var control = new LongField(label);
+                control.value = value;
+                control.RegisterValueChangedCallback(x =>
+                {
+                    var newValue = (uint)Math.Clamp(control.value, 0, uint.MaxValue);    
+                    OnValueChanged?.Invoke(newValue);
+                    control.value = newValue;
+                });
+                
+                Add(control);
+#endif
+                
             }
             else if (type == typeof(long))
             {
@@ -110,7 +126,21 @@ namespace Alchemy.Editor.Elements
             }
             else if (type == typeof(ulong))
             {
-                AddField(new UnsignedLongField(label), (ulong)obj);
+#if UNITY_2022_2_OR_NEWER
+                AddField(new UnsignedIntegerField(label), (ulong)obj);
+#else
+                var value = (ulong)obj;
+                var control = new LongField(label);
+                control.value = (long)value;
+                control.RegisterValueChangedCallback(x =>
+                {
+                    var newValue = (long)Math.Clamp(control.value, 0, long.MaxValue); 
+                    OnValueChanged?.Invoke(newValue);
+                    control.value = newValue;
+                });
+                
+                Add(control);
+#endif
             }
             else if (type == typeof(float))
             {

--- a/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
@@ -88,7 +88,7 @@ namespace Alchemy.Editor
                     if (events.OnItemsChosen == null) return;
                     ReflectionHelper.Invoke(target, events.OnItemsChosen, new object[] { items });
                 };
-#elif  UNITY_2022_1_OR_NEWER
+#else 
                  listView.onItemsChosen += items =>
                 {
                     if (events.OnItemsChosen == null) return;
@@ -113,8 +113,8 @@ namespace Alchemy.Editor
                     if (events.OnSelectedIndicesChanged== null) return;
                     ReflectionHelper.Invoke(target, events.OnSelectedIndicesChanged, new object[] { indices });
                 };
-#elif  UNITY_2022_1_OR_NEWER
-                listView.onSelectionChanged += items =>
+#else
+                listView.onSelectionChange += items =>
                 {
                     if (events.OnSelectionChanged == null) return;
                     ReflectionHelper.Invoke(target, events.OnSelectionChanged, new object[] { items });

--- a/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
@@ -82,26 +82,50 @@ namespace Alchemy.Editor
                     if (events.OnItemsRemoved == null) return;
                     ReflectionHelper.Invoke(target, events.OnItemsRemoved, new object[] { indices });
                 };
+#if UNITY_2022_2_OR_NEWER
                 listView.itemsChosen += items =>
                 {
                     if (events.OnItemsChosen == null) return;
                     ReflectionHelper.Invoke(target, events.OnItemsChosen, new object[] { items });
                 };
+#elif  UNITY_2022_1_OR_NEWER
+                 listView.onItemsChosen += items =>
+                {
+                    if (events.OnItemsChosen == null) return;
+                    ReflectionHelper.Invoke(target, events.OnItemsChosen, new object[] { items });
+                };
+#endif
+                
                 listView.itemIndexChanged += (before, after) =>
                 {
                     if (events.OnItemIndexChanged == null) return;
                     ReflectionHelper.Invoke(target, events.OnItemIndexChanged, new object[] { before, after });
                 };
+#if UNITY_2022_2_OR_NEWER
                 listView.selectionChanged += items =>
                 {
                     if (events.OnSelectionChanged == null) return;
                     ReflectionHelper.Invoke(target, events.OnSelectionChanged, new object[] { items });
                 };
+
                 listView.selectedIndicesChanged += indices =>
                 {
                     if (events.OnSelectedIndicesChanged== null) return;
                     ReflectionHelper.Invoke(target, events.OnSelectedIndicesChanged, new object[] { indices });
                 };
+#elif  UNITY_2022_1_OR_NEWER
+                listView.onSelectionChanged += items =>
+                {
+                    if (events.OnSelectionChanged == null) return;
+                    ReflectionHelper.Invoke(target, events.OnSelectionChanged, new object[] { items });
+                };
+
+                listView.onSelectedIndicesChange += indices =>
+                {
+                    if (events.OnSelectedIndicesChanged== null) return;
+                    ReflectionHelper.Invoke(target, events.OnSelectedIndicesChanged, new object[] { indices });
+                };
+#endif
                 listView.itemsSourceChanged += () =>
                 {
                     if (events.OnItemsSourceChanged == null) return;

--- a/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
@@ -82,7 +82,7 @@ namespace Alchemy.Editor
                     if (events.OnItemsRemoved == null) return;
                     ReflectionHelper.Invoke(target, events.OnItemsRemoved, new object[] { indices });
                 };
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_1_OR_NEWER
                 listView.itemsChosen += items =>
                 {
                     if (events.OnItemsChosen == null) return;
@@ -101,7 +101,7 @@ namespace Alchemy.Editor
                     if (events.OnItemIndexChanged == null) return;
                     ReflectionHelper.Invoke(target, events.OnItemIndexChanged, new object[] { before, after });
                 };
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_1_OR_NEWER
                 listView.selectionChanged += items =>
                 {
                     if (events.OnSelectionChanged == null) return;

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -225,13 +225,13 @@ namespace Alchemy.Inspector
         public string OnItemIndexChanged { get; set; }
         public string OnItemsAdded { get; set; }
         public string OnItemsRemoved { get; set; }
-#if UNITY_2022_1_OR_NEWER
+        
         public string OnItemsChosen { get; set; }
-#endif
+        
         public string OnItemsSourceChanged { get; set; }
-#if UNITY_2022_1_OR_NEWER
+        
         public string OnSelectionChanged { get; set; }
         public string OnSelectedIndicesChanged { get; set; }
-#endif
+        
     }
 }

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -225,9 +225,13 @@ namespace Alchemy.Inspector
         public string OnItemIndexChanged { get; set; }
         public string OnItemsAdded { get; set; }
         public string OnItemsRemoved { get; set; }
+#if UNITY_2022_1_OR_NEWER
         public string OnItemsChosen { get; set; }
+#endif
         public string OnItemsSourceChanged { get; set; }
+#if UNITY_2022_1_OR_NEWER
         public string OnSelectionChanged { get; set; }
         public string OnSelectedIndicesChanged { get; set; }
+#endif
     }
 }

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -225,11 +225,8 @@ namespace Alchemy.Inspector
         public string OnItemIndexChanged { get; set; }
         public string OnItemsAdded { get; set; }
         public string OnItemsRemoved { get; set; }
-        
         public string OnItemsChosen { get; set; }
-        
         public string OnItemsSourceChanged { get; set; }
-        
         public string OnSelectionChanged { get; set; }
         public string OnSelectedIndicesChanged { get; set; }
         

--- a/Alchemy/Assets/Tests/OnListViewChangedTest.cs
+++ b/Alchemy/Assets/Tests/OnListViewChangedTest.cs
@@ -8,7 +8,10 @@ public class OnListViewChangedTest : MonoBehaviour
         OnItemChanged = nameof(OnItemChanged),
         OnItemsAdded = nameof(OnItemsAdded),
         OnItemsRemoved = nameof(OnItemsRemoved),
+#if UNITY_2022_1_OR_NEWER
         OnSelectedIndicesChanged = nameof(OnSelectedIndicesChanged),
+#endif
+
         OnItemIndexChanged = nameof(OnItemIndexChanged))
     ]
     public int[] array;
@@ -27,12 +30,12 @@ public class OnListViewChangedTest : MonoBehaviour
     {
         Debug.Log($"Removed: [{string.Join(',', indices)}]");
     }
-
+#if UNITY_2022_1_OR_NEWER
     void OnSelectedIndicesChanged(IEnumerable<int> indices)
     {
         Debug.Log($"Selected: [{string.Join(',', indices)}]");
     }
-
+#endif
     void OnItemIndexChanged(int before, int after)
     {
         Debug.Log($"Index Changed: [{before} -> {after}]");

--- a/Alchemy/Assets/Tests/OnListViewChangedTest.cs
+++ b/Alchemy/Assets/Tests/OnListViewChangedTest.cs
@@ -8,6 +8,8 @@ public class OnListViewChangedTest : MonoBehaviour
         OnItemChanged = nameof(OnItemChanged),
         OnItemsAdded = nameof(OnItemsAdded),
         OnItemsRemoved = nameof(OnItemsRemoved),
+        OnItemsChosen = nameof(OnItemChosen),
+        OnSelectionChanged = nameof(OnSelectionChanged),
         OnSelectedIndicesChanged = nameof(OnSelectedIndicesChanged),
         OnItemIndexChanged = nameof(OnItemIndexChanged))
     ]
@@ -26,6 +28,16 @@ public class OnListViewChangedTest : MonoBehaviour
     void OnItemsRemoved(IEnumerable<int> indices)
     {
         Debug.Log($"Removed: [{string.Join(',', indices)}]");
+    }
+    
+    void OnItemChosen(IEnumerable<object> items)
+    {
+        Debug.Log($"Chosen: [{string.Join(',', items)}]");
+    }
+    
+    void OnSelectionChanged(IEnumerable<object> items)
+    {
+        Debug.Log($"Selection Changed: [{string.Join(',', items)}]");
     }
     
     void OnSelectedIndicesChanged(IEnumerable<int> indices)

--- a/Alchemy/Assets/Tests/OnListViewChangedTest.cs
+++ b/Alchemy/Assets/Tests/OnListViewChangedTest.cs
@@ -8,10 +8,7 @@ public class OnListViewChangedTest : MonoBehaviour
         OnItemChanged = nameof(OnItemChanged),
         OnItemsAdded = nameof(OnItemsAdded),
         OnItemsRemoved = nameof(OnItemsRemoved),
-#if UNITY_2022_1_OR_NEWER
         OnSelectedIndicesChanged = nameof(OnSelectedIndicesChanged),
-#endif
-
         OnItemIndexChanged = nameof(OnItemIndexChanged))
     ]
     public int[] array;
@@ -30,12 +27,12 @@ public class OnListViewChangedTest : MonoBehaviour
     {
         Debug.Log($"Removed: [{string.Join(',', indices)}]");
     }
-#if UNITY_2022_1_OR_NEWER
+    
     void OnSelectedIndicesChanged(IEnumerable<int> indices)
     {
         Debug.Log($"Selected: [{string.Join(',', indices)}]");
     }
-#endif
+    
     void OnItemIndexChanged(int before, int after)
     {
         Debug.Log($"Index Changed: [{before} -> {after}]");

--- a/Alchemy/Assets/Tests/UnsignedTest.cs
+++ b/Alchemy/Assets/Tests/UnsignedTest.cs
@@ -1,0 +1,19 @@
+﻿using Alchemy.Inspector;
+using UnityEngine;
+
+namespace Tests
+{
+    public class UnsignedTest : MonoBehaviour
+    {
+        [Button]
+        public void TestUint(uint value)
+        {
+            Debug.Log("TestLong");
+        }
+        [Button]
+        public void TestULong(ulong value)
+        {
+            Debug.Log("TestULong");
+        }
+    }
+}

--- a/Alchemy/Assets/Tests/UnsignedTest.cs.meta
+++ b/Alchemy/Assets/Tests/UnsignedTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b9202060cef47b8a30b53a9f413fbcb
+timeCreated: 1708998502


### PR DESCRIPTION
UnsignedIntegerField is supported in 2022.2 and later.

ListView.itemsChosenwas added in 2022.2; in ~~2022.1~~ 2021.2 its name was onItemsChosen.
selectionChanged and selectedIndicesChanged are similar to it.