### PR TITLE
Add: LabelText argument for Button attribute

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Alchemy.Inspector;
 using UnityEditor;
 using UnityEngine.UIElements;
 
@@ -17,7 +18,7 @@ namespace Alchemy.Editor.Elements
             {
                 button = new Button(() => methodInfo.Invoke(target, null))
                 {
-                    text = methodInfo.Name
+                    text = methodInfo.GetCustomAttribute<ButtonAttribute>().LabelText ?? methodInfo.Name
                 };
                 Add(button);
                 return;
@@ -30,7 +31,7 @@ namespace Alchemy.Editor.Elements
 
             foldout = new Foldout()
             {
-                text = methodInfo.Name,
+                text = methodInfo.GetCustomAttribute<ButtonAttribute>().LabelText ?? methodInfo.Name,
                 value = false,
                 style = {
                     flexGrow = 1f

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -18,7 +18,12 @@ namespace Alchemy.Inspector
     }
 
     [AttributeUsage(AttributeTargets.Method)]
-    public sealed class ButtonAttribute : Attribute { }
+    public sealed class ButtonAttribute : Attribute
+    {
+        public ButtonAttribute() => LabelText = null;
+        public ButtonAttribute(string labelText) => LabelText = labelText;
+        public string LabelText { get; }
+    }
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class ShowInInspectorAttribute : Attribute { }


### PR DESCRIPTION
I added support for the label argument in the ButtonAttribute supported in [Odin Inspector](https://odininspector.com/attributes/button-attribute) and [NaughtyAttributes](https://dbrizov.github.io/na-docs/attributes/drawer_attributes/button.html).
This works as follows:

<img width="434" alt="image" src="https://github.com/AnnulusGames/Alchemy/assets/27936152/b720c9e7-3262-44b1-928e-2cbe1b5fa055">

```cs
using System.Text;
using UnityEngine;
using Alchemy.Inspector;

namespace Alchemy.Samples
{
    public class ButtonSample : MonoBehaviour
    {
        [Button("Label for Foo()")]
        public void Foo()
        {
            Debug.Log("Foo");
        }

        [Button("Label for Foo(int)")]
        public void Foo(int parameter)
        {
            Debug.Log("Foo: " + parameter);
        }

        [Button("Label for Foo(SampleClass)")]
        public void Foo(SampleClass parameter)
        {
            var builder = new StringBuilder();
            builder.AppendLine();
            builder.Append("foo = ").AppendLine(parameter.foo.ToString());
            builder.Append("bar = ").AppendLine(parameter.bar.ToString());
            builder.Append("baz = ").Append(parameter.baz == null ? "Null" : parameter.baz.ToString());
            Debug.Log("Foo: " + builder.ToString());
        }
    }
}
```