### PR TITLE
Add:  PreviewAttribute

### DIFF
--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -137,6 +137,9 @@ namespace Alchemy.Inspector
     }
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
+    public sealed class PreviewAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
     public sealed class HorizontalLineAttribute : Attribute
     {
         public HorizontalLineAttribute()

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Samples.unity
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Samples.unity
@@ -1120,6 +1120,7 @@ Transform:
   - {fileID: 786074858}
   - {fileID: 306442429}
   - {fileID: 535909118}
+  - {fileID: 2046093442}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &978336615
@@ -2085,6 +2086,54 @@ Transform:
   - {fileID: 565026220}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2046093441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2046093442}
+  - component: {fileID: 2046093443}
+  m_Layer: 0
+  m_Name: '[Preview]'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2046093442
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046093441}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 801201067}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2046093443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046093441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36abc8eeae5f4d0482fe8f93429ee9f7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  foo: {fileID: 0}
+  bar: {fileID: 0}
+  baz: {fileID: 0}
+  qux: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/Decorations/PreviewSample.cs
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/Decorations/PreviewSample.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+using Alchemy.Inspector;
+
+namespace Alchemy.Samples
+{
+    public class PreviewSample : MonoBehaviour
+    {
+        [Preview] public Sprite foo;
+        [Preview] public Texture bar;
+        [Preview] public Material baz;
+        [Preview] public GameObject qux;
+    }
+}

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/Decorations/PreviewSample.cs.meta
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/Decorations/PreviewSample.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 36abc8eeae5f4d0482fe8f93429ee9f7
+timeCreated: 1710665552


### PR DESCRIPTION
# Overview
I have added a PreviewAttribute.

This works as follows:
<img width="534" alt="image" src="https://github.com/AnnulusGames/Alchemy/assets/27964732/ecb4e25a-0362-459a-ad1d-c26330a34533">

```cs
using UnityEngine;
using Alchemy.Inspector;

namespace Alchemy.Samples
{
    public class PreviewSample : MonoBehaviour
    {
        [Preview] public Sprite foo;
        [Preview] public Texture bar;
        [Preview] public Material baz;
        [Preview] public GameObject qux;
    }
}
```

# Sample
I created `PreviewSample.cs` and added a [Preview] object to the [Decorations] child object in Sample.unity.
You can revert the commit if you do not need it.

# References
AssetPreview: https://docs.unity3d.com/2022.3/Documentation/ScriptReference/AssetPreview.html