### PR TITLE
Fix: typo in subtitle

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -271,9 +271,9 @@ namespace Alchemy.Editor.Drawers
             };
             parent.Insert(parent.IndexOf(TargetElement), title);
 
-            if (att.SubitleText != null)
+            if (att.SubtitleText != null)
             {
-                var subtitle = new Label(att.SubitleText)
+                var subtitle = new Label(att.SubtitleText)
                 {
                     style = {
                         fontSize = 10f,

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -164,18 +164,18 @@ namespace Alchemy.Inspector
         public TitleAttribute(string titleText)
         {
             TitleText = titleText;
-            SubitleText = null;
+            SubtitleText = null;
         }
 
         public TitleAttribute(string titleText, string subtitle)
         {
             TitleText = titleText;
-            SubitleText = subtitle;
+            SubtitleText = subtitle;
         }
 
 
         public string TitleText { get; }
-        public string SubitleText { get; }
+        public string SubtitleText { get; }
     }
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]


### PR DESCRIPTION
Issue: https://github.com/AnnulusGames/Alchemy/issues/71

Fixed the typo in "subtitle".
Just to be sure, I confirmed that the TitleSample is displayed correctly.

<img width="526" alt="image" src="https://github.com/AnnulusGames/Alchemy/assets/27964732/4c41f85e-5808-4dc1-80c1-cfb2e2778051">
