### PR TITLE
Add: LabelText with Button support

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -100,6 +100,9 @@ namespace Alchemy.Editor.Drawers
                 case AlchemyPropertyField alchemyPropertyField:
                     alchemyPropertyField.Label = labelTextAttribute.Text;
                     break;
+                case MethodButton methodButton:
+                    methodButton.SetLableText(labelTextAttribute.Text);
+                    break;
                 case Button button:
                     button.text = labelTextAttribute.Text;
                     break;

--- a/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
@@ -69,5 +69,15 @@ namespace Alchemy.Editor.Elements
 
         readonly Foldout foldout;
         readonly Button button;
+
+        public void SetLableText(string labelText) {
+            var foldout = this.Q<Foldout>();
+            if (foldout != null) {
+                foldout.text = labelText;
+            }
+            else {
+                this.Q<Button>().text = labelText;
+            }
+        }
     }
 }

--- a/Alchemy/Assets/Alchemy/Editor/Elements/ReflectionField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/ReflectionField.cs
@@ -23,6 +23,9 @@ namespace Alchemy.Editor.Elements
                 if (methodInfo.HasCustomAttribute<ButtonAttribute>())
                 {
                     var button = new MethodButton(target, methodInfo);
+                    if (methodInfo.TryGetCustomAttribute(out LabelTextAttribute labelText)) {
+                        button.SetLableText(labelText.Text);
+                    }
                     Add(button);
                 }
                 return;

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/General/ButtonSample.cs
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/General/ButtonSample.cs
@@ -6,19 +6,19 @@ namespace Alchemy.Samples
 {
     public class ButtonSample : MonoBehaviour
     {
-        [Button]
+        [Button, LabelText("Label for Foo()")]
         public void Foo()
         {
             Debug.Log("Foo");
         }
 
-        [Button]
+        [Button, LabelText("Foo (int)")]
         public void Foo(int parameter)
         {
             Debug.Log("Foo: " + parameter);
         }
 
-        [Button]
+        [Button, LabelText("Foo (SampleClass)")]
         public void Foo(SampleClass parameter)
         {
             var builder = new StringBuilder();


### PR DESCRIPTION
I added support for Button label change with LabelText attribute.
Updated ButtonSample.cs and in inspector it looks like this:

![image](https://github.com/AnnulusGames/Alchemy/assets/63865477/f1213e64-bd69-4838-a182-def8fd8d3f4a)

```csharp
using System.Text;
using UnityEngine;
using Alchemy.Inspector;

namespace Alchemy.Samples
{
    public class ButtonSample : MonoBehaviour
    {
        [Button, LabelText("Label for Foo()")]
        public void Foo()
        {
            Debug.Log("Foo");
        }

        [Button, LabelText("Foo (int)")]
        public void Foo(int parameter)
        {
            Debug.Log("Foo: " + parameter);
        }

        [Button, LabelText("Foo (SampleClass)")]
        public void Foo(SampleClass parameter)
        {
            var builder = new StringBuilder();
            builder.AppendLine();
            builder.Append("foo = ").AppendLine(parameter.foo.ToString());
            builder.Append("bar = ").AppendLine(parameter.bar.ToString());
            builder.Append("baz = ").Append(parameter.baz == null ? "Null" : parameter.baz.ToString());
            Debug.Log("Foo: " + builder.ToString());
        }
    }
}
```