### PR TITLE
Add: Preview attribute size and align

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -243,23 +243,24 @@ namespace Alchemy.Editor.Drawers
     public sealed class PreviewDrawer : TrackSerializedObjectAttributeDrawer
     {
         private Image image;
-        private const float PreviewSize = 40f;
         private const float BorderWidth = 1f;
         private static readonly Color borderColor = new Color(0f, 0f, 0f, 0.3f);
 
         public override void OnCreateElement()
         {
-            if (SerializedProperty.propertyType != SerializedPropertyType.ObjectReference) return;
+            if (SerializedProperty == null || SerializedProperty.propertyType != SerializedPropertyType.ObjectReference) return;
+
+            var att = (PreviewAttribute)Attribute;
 
             image = new Image
             {
                 scaleMode = ScaleMode.ScaleToFit,
                 style = {
-                    width = PreviewSize,
-                    height = PreviewSize,
+                    width = att.Size,
+                    height = att.Size,
                     marginTop = EditorGUIUtility.standardVerticalSpacing,
                     marginBottom = EditorGUIUtility.standardVerticalSpacing * 4f,
-                    alignSelf = Align.FlexEnd,
+                    alignSelf = att.AlignStyle,
                     borderTopWidth = BorderWidth,
                     borderBottomWidth = BorderWidth,
                     borderLeftWidth = BorderWidth,

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/InspectorAttributes.cs
@@ -137,7 +137,19 @@ namespace Alchemy.Inspector
     }
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
-    public sealed class PreviewAttribute : Attribute { }
+    public sealed class PreviewAttribute : Attribute { 
+        public PreviewAttribute() : this(40, Align.FlexEnd) { }
+
+        public PreviewAttribute(float size) : this (size, Align.FlexEnd) { }
+
+        public PreviewAttribute(float size, Align align) {
+            Size = size;
+            AlignStyle = align;
+        }
+
+        public float Size { get; }
+        public StyleEnum<Align> AlignStyle { get; }
+    }
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
     public sealed class HorizontalLineAttribute : Attribute

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/Decorations/PreviewSample.cs
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/Decorations/PreviewSample.cs
@@ -1,12 +1,13 @@
 using UnityEngine;
 using Alchemy.Inspector;
+using UnityEngine.UIElements;
 
 namespace Alchemy.Samples
 {
     public class PreviewSample : MonoBehaviour
     {
-        [Preview] public Sprite foo;
-        [Preview] public Texture bar;
+        [Preview(64, Align.FlexStart)] public Sprite foo;
+        [Preview(64, Align.Center)] public Texture bar;
         [Preview] public Material baz;
         [Preview] public GameObject qux;
     }


### PR DESCRIPTION
Added Preview attribute size and align arguments. Size was in [NaughtyAttributes](https://dbrizov.github.io/na-docs/attributes/drawer_attributes/show_asset_preview.html) and it was aligned differently.
Fixed exception if [Preview] attrubute used in generic class and object of generic class was [Button] attribute method as argument.
Updated samples, here is how it looks now:

![image](https://github.com/AnnulusGames/Alchemy/assets/63865477/4834a457-4399-492d-860e-b97fe0de712c)

```csharp
using UnityEngine;
using Alchemy.Inspector;
using UnityEngine.UIElements;

namespace Alchemy.Samples
{
    public class PreviewSample : MonoBehaviour
    {
        [Preview(64, Align.FlexStart)] public Sprite foo;
        [Preview(64, Align.Center)] public Texture bar;
        [Preview] public Material baz;
        [Preview] public GameObject qux;
    }
}

```