### PR TITLE
Fix for InternalAPIHelper Error in Unity 2023.2.15f1 and Later

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Elements/AlchemyPropertyField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/AlchemyPropertyField.cs
@@ -32,8 +32,9 @@ namespace Alchemy.Editor.Elements
                     break;
                 case SerializedPropertyType.Generic:
                     var targetType = property.GetPropertyType(isArrayElement);
+                    var isManagedReferenceProperty = property.propertyType == SerializedPropertyType.ManagedReference;
 
-                    if (InternalAPIHelper.GetDrawerTypeForType(targetType) != null)
+                    if (InternalAPIHelper.GetDrawerTypeForType(targetType, isManagedReferenceProperty) != null)
                     {
                         element = new PropertyField(property);
                     }

--- a/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
@@ -118,10 +118,11 @@ namespace Alchemy.Editor
 
                     VisualElement element = null;
                     var property = findPropertyFunc(member.Name);
+                    var isManagedReferenceProperty = property?.propertyType == SerializedPropertyType.ManagedReference;
 
                     // Add default PropertyField if the property has a custom PropertyDrawer
-                    if ((member is FieldInfo fieldInfo && InternalAPIHelper.GetDrawerTypeForType(fieldInfo.FieldType) != null) ||
-                        (member is PropertyInfo propertyInfo && InternalAPIHelper.GetDrawerTypeForType(propertyInfo.PropertyType) != null))
+                    if ((member is FieldInfo fieldInfo && InternalAPIHelper.GetDrawerTypeForType(fieldInfo.FieldType, isManagedReferenceProperty) != null) ||
+                        (member is PropertyInfo propertyInfo && InternalAPIHelper.GetDrawerTypeForType(propertyInfo.PropertyType, isManagedReferenceProperty) != null))
                     {
                         if (property != null)
                         {


### PR DESCRIPTION
This pull request addresses an issue that changed the signature of the GetDrawerTypeForType method in Unity 2023.2.15f1 and later versions, including Unity 2023.3.
These changes were causing errors in InternalAPIHelper.
This PR fix ensures compatibility and resolves the error.