### PR TITLE
Fix: Resolved InternalAPIHelper error in Unity 2022.3.23f1 and later

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/InternalAPIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/InternalAPIHelper.cs
@@ -39,6 +39,14 @@ namespace Alchemy.Editor
             {
                 return (Type)methodInfo.Invoke(instance, new object[] { classType });
             }
+#elif UNITY_2022_3_OR_NEWER
+            // Unity 2022.3.23f1 added a new parameter to the method
+            var version = UnityEditorInternal.InternalEditorUtility.GetUnityVersion();
+            if (version.Build >= 23)
+            {
+                return (Type)methodInfo?.Invoke(instance, new object[] { classType, isManagedReferenceProperty });
+            }
+            return (Type)methodInfo?.Invoke(instance, new object[] { classType });
 #else
             _ = isManagedReferenceProperty; // discard
             return (Type)methodInfo.Invoke(instance, new object[] { classType });


### PR DESCRIPTION
This fix is similar to #88 but for Unity 2022.3.

I checked version changes on https://github.com/Unity-Technologies/UnityCsReference and with this fix the bug issue should be closed for all versions of Unity.