### PR TITLE
Fix display of RectOffset in inspector

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Elements/AlchemyPropertyField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/AlchemyPropertyField.cs
@@ -17,6 +17,8 @@ namespace Alchemy.Editor.Elements
 
             switch (property.propertyType)
             {
+                // NOTE: RectOffset is a generic property type, but it doesn't have a SerializeField. Instead, use PropertyField.
+                case SerializedPropertyType.Generic when property.type == "RectOffset":
                 default:
                     element = new PropertyField(property);
                     break;

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Samples.unity
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Samples.unity
@@ -2055,6 +2055,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 10a01c03cb52744d29a15035954b9bd2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  qux:
+    m_Left: 1
+    m_Right: 2
+    m_Top: 3
+    m_Bottom: 4
   foo: 0
   bar: {x: 0, y: 0, z: 0}
   baz: {fileID: 0}

--- a/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/General/OrderSample.cs
+++ b/Alchemy/Assets/Alchemy/Samples~/Samples/Scripts/General/OrderSample.cs
@@ -5,6 +5,7 @@ namespace Alchemy.Samples
 {
     public class OrderSample : MonoBehaviour
     {
+        [Order(3)] public RectOffset qux;
         [Order(2)] public float foo;
         [Order(1)] public Vector3 bar;
         [Order(0)] public GameObject baz;


### PR DESCRIPTION
Before this fix, the AlchemyPropertyField used InspectorHelper.BuildElements to construct the properties displayed in the Inspector for RectOffset.
However, since RectOffset doesn't have managed SerializeFields, nothing was being displayed.

In this PR, I've modified the handling of RectOffset to treat it like other built-in Unity types (such as Vector3, etc.) within PropertyField.
This change ensures that RectOffset is now properly displayed in the Inspector.