### PR TITLE
Add: Serialize Reference copy and paste item data support

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/ManagedReferenceContextMenuExtension.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/ManagedReferenceContextMenuExtension.cs
@@ -1,0 +1,57 @@
+﻿#if UNITY_2021_3_OR_NEWER
+using UnityEditor;
+using UnityEngine;
+
+namespace Alchemy.Editor {
+    public static class ManagedReferenceContextMenuExtension {
+
+        private const string CLIPBOARD_KEY = "AlchemyExtensions.CopyAndPasteManagedProperty";
+        private const string COPIED_PROPERTY_PATH_KEY = "AlchemyExtensions.CopiedManagedPropertyPath";
+
+        private static readonly GUIContent CopyProperty = new("Copy Property");
+        private static readonly GUIContent PasteProperty = new("Paste Property");
+
+        [InitializeOnLoadMethod]
+        private static void Initialize() {
+            EditorApplication.contextualPropertyMenu += OnContextualPropertyMenu;
+        }
+
+        private static void OnContextualPropertyMenu(GenericMenu menu, SerializedProperty property) {
+            if (property.propertyType == SerializedPropertyType.ManagedReference) {
+
+                SerializedProperty clonedProperty = property.Copy();
+                menu.AddItem(CopyProperty, false, Copy, clonedProperty);
+
+                string copiedPropertyPath = SessionState.GetString(COPIED_PROPERTY_PATH_KEY, string.Empty);
+                if (!string.IsNullOrEmpty(copiedPropertyPath)) {
+                    menu.AddItem(PasteProperty, false, Paste, clonedProperty);
+                }
+                else {
+                    menu.AddDisabledItem(PasteProperty);
+                }
+
+                menu.AddSeparator("");
+            }
+        }
+
+        private static void Copy(object serializedPropertyObject) {
+            SerializedProperty property = (SerializedProperty)serializedPropertyObject;
+            string json = JsonUtility.ToJson(property.managedReferenceValue);
+            SessionState.SetString(COPIED_PROPERTY_PATH_KEY, property.propertyPath);
+            SessionState.SetString(CLIPBOARD_KEY, json);
+        }
+
+        private static void Paste(object serializedPropertyObject) {
+            SerializedProperty property = (SerializedProperty)serializedPropertyObject;
+            string json = SessionState.GetString(CLIPBOARD_KEY, string.Empty);
+            if (string.IsNullOrEmpty(json)) {
+                return;
+            }
+
+            Undo.RecordObject(property.serializedObject.targetObject, PasteProperty.text);
+            JsonUtility.FromJsonOverwrite(json, property.managedReferenceValue);
+            property.serializedObject.ApplyModifiedProperties();
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Editor/Internal/ManagedReferenceContextMenuExtension.cs.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/ManagedReferenceContextMenuExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f3d08b9bd5850442a8eacb8b1cb7f05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Was working with SerializeReference and noticed that I can't copy-paste data which is annoying.

Previously I was using Mackysoft Unity-SerializeReferenceExtensions which has copy-paste support and was made to serialize references to interfaces and abstract classes.

Example how to use:
![image](https://github.com/AnnulusGames/Alchemy/assets/63865477/734b4764-3e14-4775-9743-7614d5d46fce)
- Set correspond class before paste
![image](https://github.com/AnnulusGames/Alchemy/assets/63865477/1b52832b-a38f-4667-beef-50542f5b5ea8)
- 
![image](https://github.com/AnnulusGames/Alchemy/assets/63865477/dafee247-db9a-4c86-98fc-004c1fd32602)
![image](https://github.com/AnnulusGames/Alchemy/assets/63865477/9b29e65d-dfd8-4e62-914e-e72170432b95)

Hope it will help someone.