### PR TITLE
Moving inline styles to stylesheets

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -242,35 +242,19 @@ namespace Alchemy.Editor.Drawers
     [CustomAttributeDrawer(typeof(PreviewAttribute))]
     public sealed class PreviewDrawer : TrackSerializedObjectAttributeDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/PreviewDrawer-Styles");
         private Image image;
-        private const float PreviewSize = 40f;
-        private const float BorderWidth = 1f;
-        private static readonly Color borderColor = new Color(0f, 0f, 0f, 0.3f);
 
         public override void OnCreateElement()
         {
             if (SerializedProperty.propertyType != SerializedPropertyType.ObjectReference) return;
 
-            image = new Image
-            {
-                scaleMode = ScaleMode.ScaleToFit,
-                style = {
-                    width = PreviewSize,
-                    height = PreviewSize,
-                    marginTop = EditorGUIUtility.standardVerticalSpacing,
-                    marginBottom = EditorGUIUtility.standardVerticalSpacing * 4f,
-                    alignSelf = Align.FlexEnd,
-                    borderTopWidth = BorderWidth,
-                    borderBottomWidth = BorderWidth,
-                    borderLeftWidth = BorderWidth,
-                    borderRightWidth = BorderWidth,
-                    borderBottomColor = borderColor,
-                    borderTopColor = borderColor,
-                    borderLeftColor = borderColor,
-                    borderRightColor = borderColor,
-                }
-            };
+            image = new Image();
 
+            image.styleSheets.Add(_styleSheet);
+            image.AddToClassList("alchemy-attribute-preview_drawer-image");
+            image.AddToClassList("align-right");
+            
             image.RegisterCallback<MouseDownEvent>(x =>
             {
                 using var mouseDownEvent = MouseDownEvent.GetPooled(x);
@@ -317,34 +301,26 @@ namespace Alchemy.Editor.Drawers
     [CustomAttributeDrawer(typeof(TitleAttribute))]
     public sealed class TitleDrawer : AlchemyAttributeDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/TitleDrawer-Attribute-Styles");
+
         public override void OnCreateElement()
         {
             var att = (TitleAttribute)Attribute;
             var parent = TargetElement.parent;
 
-            var title = new Label(att.TitleText)
-            {
-                style = {
-                    unityFontStyleAndWeight = FontStyle.Bold,
-                    paddingLeft = 3f,
-                    marginTop = 4f,
-                    marginBottom = -2f
-                }
-            };
+            var title = new Label(att.TitleText);
+            
+            title.styleSheets.Add(_styleSheet);
+            title.AddToClassList("alchemy-attribute-title_drawer-title");
+            
             parent.Insert(parent.IndexOf(TargetElement), title);
 
             if (att.SubtitleText != null)
             {
-                var subtitle = new Label(att.SubtitleText)
-                {
-                    style = {
-                        fontSize = 10f,
-                        paddingLeft = 4.5f,
-                        marginTop = 1.5f,
-                        color = GUIHelper.SubtitleColor,
-                        unityTextAlign = TextAnchor.MiddleLeft
-                    }
-                };
+                var subtitle = new Label(att.SubtitleText);
+                
+                subtitle.styleSheets.Add(_styleSheet);
+                subtitle.AddToClassList("alchemy-attribute-title_drawer-subtitle");
                 parent.Insert(parent.IndexOf(TargetElement), subtitle);
             }
 

--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -252,8 +252,8 @@ namespace Alchemy.Editor.Drawers
             image = new Image();
 
             image.styleSheets.Add(_styleSheet);
-            image.AddToClassList("alchemy-attribute-preview_drawer-image");
-            image.AddToClassList("align-right");
+            image.AddToClassList("preview-attribute__image");
+            image.AddToClassList("preview-attribute__image--align-right");
             
             image.RegisterCallback<MouseDownEvent>(x =>
             {
@@ -311,7 +311,7 @@ namespace Alchemy.Editor.Drawers
             var title = new Label(att.TitleText);
             
             title.styleSheets.Add(_styleSheet);
-            title.AddToClassList("alchemy-attribute-title_drawer-title");
+            title.AddToClassList("title-attribute__title");
             
             parent.Insert(parent.IndexOf(TargetElement), title);
 
@@ -320,7 +320,7 @@ namespace Alchemy.Editor.Drawers
                 var subtitle = new Label(att.SubtitleText);
                 
                 subtitle.styleSheets.Add(_styleSheet);
-                subtitle.AddToClassList("alchemy-attribute-title_drawer-subtitle");
+                subtitle.AddToClassList("title-attribute__subtitle");
                 parent.Insert(parent.IndexOf(TargetElement), subtitle);
             }
 

--- a/Alchemy/Assets/Alchemy/Editor/BuiltinGroupDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinGroupDrawers.cs
@@ -1,59 +1,41 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
-using UnityEngine.UIElements;
+using Alchemy.Editor.Elements;
+using Alchemy.Inspector;
 using UnityEditor;
 using UnityEditor.UIElements;
-using Alchemy.Inspector;
-using Alchemy.Editor.Elements;
+using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace Alchemy.Editor.Drawers
 {
     [CustomGroupDrawer(typeof(GroupAttribute))]
     public sealed class GroupDrawer : AlchemyGroupDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/GroupDrawer-Styles");
+
         public override VisualElement CreateRootElement(string label)
         {
-            return new Box()
-            {
-                style = {
-                    width = Length.Percent(100f),
-                    marginTop = 3f,
-                    paddingBottom = 2f,
-                    paddingRight = 1f,
-                    paddingLeft = 1f,
-                }
-            };
+            Box box = new();
+            box.styleSheets.Add(_styleSheet);
+            box.AddToClassList("alchemy-group_attribute-group_drawer-box");
+            return box;
         }
     }
 
     [CustomGroupDrawer(typeof(BoxGroupAttribute))]
     public sealed class BoxGroupDrawer : AlchemyGroupDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/BoxGroupDrawer-Styles");
+
         public override VisualElement CreateRootElement(string label)
         {
-            var helpBox = new HelpBox()
-            {
-                text = label,
-                style = {
-                    flexDirection = FlexDirection.Column,
-                    width = Length.Percent(100f),
-                    marginTop = 3f,
-                    paddingBottom = 3f,
-                    paddingRight = 3f,
-                    paddingLeft = 3f,
-                }
-            };
-
-            var labelElement = helpBox.Q<Label>();
-            labelElement.style.top = 2f;
-            labelElement.style.left = 2f;
-            labelElement.style.fontSize = 12f;
-            labelElement.style.minHeight = EditorGUIUtility.singleLineHeight;
-            labelElement.style.unityFontStyleAndWeight = FontStyle.Bold;
-            labelElement.style.alignSelf = Align.Stretch;
-
+            var helpBox = new HelpBox { text = label };
+            
+            helpBox.styleSheets.Add(_styleSheet);
+            helpBox.AddToClassList("alchemy-group_attribute-box_group_drawer-help_box");
+            
             return helpBox;
         }
     }
@@ -61,7 +43,10 @@ namespace Alchemy.Editor.Drawers
     [CustomGroupDrawer(typeof(TabGroupAttribute))]
     public sealed class TabGroupDrawer : AlchemyGroupDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/TabGroupDrawer-Styles");
+        
         VisualElement rootElement;
+        private VisualElement pageRoot;
         readonly Dictionary<string, VisualElement> tabElements = new();
 
         string[] keyArrayCache = new string[0];
@@ -80,19 +65,12 @@ namespace Alchemy.Editor.Drawers
             int.TryParse(EditorUserSettings.GetConfigValue(configKey), out tabIndex);
             prevTabIndex = tabIndex;
 
-            rootElement = new HelpBox()
-            {
-                style = {
-                    flexDirection = FlexDirection.Column,
-                    width = Length.Percent(100f),
-                    marginTop = 3f,
-                    paddingBottom = 3f,
-                    paddingRight = 3f,
-                    paddingLeft = 3f,
-                }
-            };
+            rootElement = new HelpBox();
             rootElement.Remove(rootElement.Q<Label>());
 
+            rootElement.styleSheets.Add(_styleSheet);
+            rootElement.AddToClassList("alchemy-group_attribute-tab_group_drawer-help_box");
+            
             var tabGUIElement = new IMGUIContainer(() =>
             {
                 var rect = EditorGUILayout.GetControlRect();
@@ -111,17 +89,13 @@ namespace Alchemy.Editor.Drawers
                 {
                     kv.Value.style.display = keyArrayCache[tabIndex] == kv.Key ? DisplayStyle.Flex : DisplayStyle.None;
                 }
-            })
-            {
-                style = {
-                    width = Length.Percent(100f),
-                    marginLeft = 0f,
-                    marginRight = 0f,
-                    marginTop = 0f
-                }
-            };
+            });
+            
             rootElement.Add(tabGUIElement);
 
+            pageRoot = new VisualElement { name = "page-root" };
+            rootElement.Add(pageRoot);
+            
             return rootElement;
         }
 
@@ -132,13 +106,9 @@ namespace Alchemy.Editor.Drawers
             var tabName = tabGroupAttribute.TabName;
             if (!tabElements.TryGetValue(tabName, out var element))
             {
-                element = new VisualElement()
-                {
-                    style = {
-                        width = Length.Percent(100f)
-                    }
-                };
-                rootElement.Add(element);
+                element = new VisualElement();
+                element.AddToClassList("tab-page");
+                pageRoot.Add(element);
                 tabElements.Add(tabName, element);
 
                 keyArrayCache = tabElements.Keys.ToArray();
@@ -151,19 +121,21 @@ namespace Alchemy.Editor.Drawers
     [CustomGroupDrawer(typeof(FoldoutGroupAttribute))]
     public sealed class FoldoutGroupDrawer : AlchemyGroupDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/FoldoutGroupDrawer-Styles");
+        
         public override VisualElement CreateRootElement(string label)
         {
             var configKey = UniqueId + "_FoldoutGroup";
             bool.TryParse(EditorUserSettings.GetConfigValue(configKey), out var result);
 
-            var foldout = new Foldout()
+            var foldout = new Foldout
             {
-                style = {
-                    width = Length.Percent(100f)
-                },
                 text = label,
                 value = result
             };
+            
+            foldout.styleSheets.Add(_styleSheet);
+            foldout.AddToClassList("alchemy-group_attribute-foldout_group_drawer-foldout");
 
             foldout.RegisterValueChangedCallback(x =>
             {
@@ -177,15 +149,14 @@ namespace Alchemy.Editor.Drawers
     [CustomGroupDrawer(typeof(HorizontalGroupAttribute))]
     public sealed class HorizontalGroupDrawer : AlchemyGroupDrawer
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/HorizontalGroupDrawer-Styles");
+        
         public override VisualElement CreateRootElement(string label)
         {
-            var root = new VisualElement()
-            {
-                style = {
-                    width = Length.Percent(100f),
-                    flexDirection = FlexDirection.Row
-                }
-            };
+            var root = new VisualElement();
+            
+            root.styleSheets.Add(_styleSheet);
+            root.AddToClassList("alchemy-group_attribute-horizontal_group_drawer-visual_element");
 
             static void AdjustLabel(PropertyField element, VisualElement inspector, int childCount)
             {
@@ -197,10 +168,7 @@ namespace Alchemy.Editor.Drawers
 
                 var labelElement = field.Q<Label>();
                 if (labelElement != null)
-                {
-                    labelElement.style.minWidth = 0f;
                     labelElement.style.width = GUIHelper.CalculateLabelWidth(element, inspector) * 0.8f / childCount;
-                }
             }
 
             root.schedule.Execute(() =>
@@ -211,11 +179,11 @@ namespace Alchemy.Editor.Drawers
 
                 foreach (var field in root.Query<PropertyField>().Build())
                 {
-                    AdjustLabel(field, visualTree, root.childCount);
+                    field.schedule.Execute(() => AdjustLabel(field, visualTree, root.childCount));
                 }
                 foreach (var field in root.Query<GenericField>().Children<PropertyField>().Build())
                 {
-                    AdjustLabel(field, visualTree, root.childCount);
+                    field.schedule.Execute(() => AdjustLabel(field, visualTree, root.childCount));
                 }
             });
 

--- a/Alchemy/Assets/Alchemy/Editor/BuiltinGroupDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinGroupDrawers.cs
@@ -19,7 +19,7 @@ namespace Alchemy.Editor.Drawers
         {
             Box box = new();
             box.styleSheets.Add(_styleSheet);
-            box.AddToClassList("alchemy-group_attribute-group_drawer-box");
+            box.AddToClassList("group__box");
             return box;
         }
     }
@@ -34,7 +34,7 @@ namespace Alchemy.Editor.Drawers
             var helpBox = new HelpBox { text = label };
             
             helpBox.styleSheets.Add(_styleSheet);
-            helpBox.AddToClassList("alchemy-group_attribute-box_group_drawer-help_box");
+            helpBox.AddToClassList("box-group__help-box");
             
             return helpBox;
         }
@@ -69,7 +69,7 @@ namespace Alchemy.Editor.Drawers
             rootElement.Remove(rootElement.Q<Label>());
 
             rootElement.styleSheets.Add(_styleSheet);
-            rootElement.AddToClassList("alchemy-group_attribute-tab_group_drawer-help_box");
+            rootElement.AddToClassList("tab-group__help-box");
             
             var tabGUIElement = new IMGUIContainer(() =>
             {
@@ -90,10 +90,13 @@ namespace Alchemy.Editor.Drawers
                     kv.Value.style.display = keyArrayCache[tabIndex] == kv.Key ? DisplayStyle.Flex : DisplayStyle.None;
                 }
             });
+            tabGUIElement.AddToClassList("tab-group__tab-section");
             
             rootElement.Add(tabGUIElement);
 
-            pageRoot = new VisualElement { name = "page-root" };
+            pageRoot = new VisualElement();
+            pageRoot.AddToClassList("tab-group__page-root");
+            
             rootElement.Add(pageRoot);
             
             return rootElement;
@@ -107,7 +110,7 @@ namespace Alchemy.Editor.Drawers
             if (!tabElements.TryGetValue(tabName, out var element))
             {
                 element = new VisualElement();
-                element.AddToClassList("tab-page");
+                element.AddToClassList("tab-group__tab-page");
                 pageRoot.Add(element);
                 tabElements.Add(tabName, element);
 
@@ -135,7 +138,7 @@ namespace Alchemy.Editor.Drawers
             };
             
             foldout.styleSheets.Add(_styleSheet);
-            foldout.AddToClassList("alchemy-group_attribute-foldout_group_drawer-foldout");
+            foldout.AddToClassList("foldout-group__foldout");
 
             foldout.RegisterValueChangedCallback(x =>
             {
@@ -156,7 +159,7 @@ namespace Alchemy.Editor.Drawers
             var root = new VisualElement();
             
             root.styleSheets.Add(_styleSheet);
-            root.AddToClassList("alchemy-group_attribute-horizontal_group_drawer-visual_element");
+            root.AddToClassList("horizontal-group__main-element");
 
             static void AdjustLabel(PropertyField element, VisualElement inspector, int childCount)
             {

--- a/Alchemy/Assets/Alchemy/Editor/Elements/ClassField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/ClassField.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using UnityEngine.UIElements;
 using Alchemy.Inspector;
+using UnityEngine;
 
 namespace Alchemy.Editor.Elements
 {
@@ -10,6 +11,9 @@ namespace Alchemy.Editor.Elements
         public ClassField(Type type, string label) : this(TypeHelper.CreateDefaultInstance(type), type, label) { }
         public ClassField(object obj, Type type, string label)
         {
+            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/ClassField-Styles");
+            styleSheets.Add(styleSheet);
+
             var foldout = new Foldout
             {
                 text = label,
@@ -45,7 +49,7 @@ namespace Alchemy.Editor.Elements
                 foreach (var member in node.Members.OrderByAttributeThenByMemberType())
                 {
                     var element = new ReflectionField(obj, member);
-                    element.style.width = Length.Percent(100f);
+                    element.AddToClassList("alchemy-class_field-element");
                     element.OnValueChanged += x => OnValueChanged?.Invoke(obj);
 
                     var e = node.Drawer?.GetGroupElement(member.GetCustomAttribute<PropertyGroupAttribute>());

--- a/Alchemy/Assets/Alchemy/Editor/Elements/ClassField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/ClassField.cs
@@ -8,11 +8,12 @@ namespace Alchemy.Editor.Elements
 {
     public sealed class ClassField : VisualElement
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/ClassField-Styles");
+        
         public ClassField(Type type, string label) : this(TypeHelper.CreateDefaultInstance(type), type, label) { }
         public ClassField(object obj, Type type, string label)
         {
-            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/ClassField-Styles");
-            styleSheets.Add(styleSheet);
+            styleSheets.Add(_styleSheet);
 
             var foldout = new Foldout
             {
@@ -49,7 +50,7 @@ namespace Alchemy.Editor.Elements
                 foreach (var member in node.Members.OrderByAttributeThenByMemberType())
                 {
                     var element = new ReflectionField(obj, member);
-                    element.AddToClassList("alchemy-class_field-element");
+                    element.AddToClassList("class-field__reflection-field");
                     element.OnValueChanged += x => OnValueChanged?.Invoke(obj);
 
                     var e = node.Drawer?.GetGroupElement(member.GetCustomAttribute<PropertyGroupAttribute>());

--- a/Alchemy/Assets/Alchemy/Editor/Elements/DictionaryField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/DictionaryField.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -10,6 +9,9 @@ namespace Alchemy.Editor.Elements
     {
         public DictionaryField(object collection, string label) : base(collection, label)
         {
+            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/DictionaryField-Styles");
+            styleSheets.Add(styleSheet);
+
             if (collection != null)
             {
                 keyType = collection.GetType().GenericTypeArguments[0];
@@ -69,14 +71,9 @@ namespace Alchemy.Editor.Elements
         {
             public Item(object collection, object keyValuePair)
             {
-                var box = new Box()
-                {
-                    style = {
-                        marginBottom = 3.5f,
-                        marginRight = -2f,
-                        flexDirection = FlexDirection.Row
-                    }
-                };
+                AddToClassList("alchemy-dictionary_item");
+                
+                var box = new Box();
 
                 kvType = keyValuePair.GetType();
                 var keyType = kvType.GenericTypeArguments[0];
@@ -88,38 +85,21 @@ namespace Alchemy.Editor.Elements
                 this.collection = collection;
                 this.keyValuePair = keyValuePair;
 
-                var keyValueElement = new VisualElement()
-                {
-                    style = {
-                        flexDirection = FlexDirection.Column,
-                        flexGrow = 1f
-                    }
-                };
+                var keyValueElement = new VisualElement { name = "key-value-element" };
                 box.Add(keyValueElement);
 
-                keyField = new GenericField(key, keyType, KeyName)
-                {
-                    style = { flexGrow = 1f }
-                };
+                keyField = new GenericField(key, keyType, KeyName) { name = "key-field" };
                 keyField.OnValueChanged += SetKey;
                 keyValueElement.Add(keyField);
 
-                valueField = new GenericField(value, valueType, ValueName)
-                {
-                    style = { flexGrow = 1f }
-                };
+                valueField = new GenericField(value, valueType, ValueName) { name = "value-field" };
                 valueField.OnValueChanged += SetValue;
                 keyValueElement.Add(valueField);
 
                 var closeButton = new Button(() => OnClose?.Invoke())
                 {
-                    style = {
-                        width = EditorGUIUtility.singleLineHeight,
-                        height = EditorGUIUtility.singleLineHeight,
-                        unityFontStyleAndWeight = FontStyle.Bold,
-                        fontSize = 10f
-                    },
-                    text = "X",
+                    name = "close-button",
+                    text = "X"
                 };
                 box.Add(closeButton);
                 Add(box);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/DictionaryField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/DictionaryField.cs
@@ -7,10 +7,11 @@ namespace Alchemy.Editor.Elements
 {
     public sealed class DictionaryField : HashMapFieldBase
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/DictionaryField-Styles");
+        
         public DictionaryField(object collection, string label) : base(collection, label)
         {
-            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/DictionaryField-Styles");
-            styleSheets.Add(styleSheet);
+            styleSheets.Add(_styleSheet);
 
             if (collection != null)
             {
@@ -71,9 +72,10 @@ namespace Alchemy.Editor.Elements
         {
             public Item(object collection, object keyValuePair)
             {
-                AddToClassList("alchemy-dictionary_item");
+                AddToClassList("dictionary-field__item");
                 
                 var box = new Box();
+                box.AddToClassList("dictionary-field__item__box");
 
                 kvType = keyValuePair.GetType();
                 var keyType = kvType.GenericTypeArguments[0];
@@ -85,22 +87,23 @@ namespace Alchemy.Editor.Elements
                 this.collection = collection;
                 this.keyValuePair = keyValuePair;
 
-                var keyValueElement = new VisualElement { name = "key-value-element" };
+                var keyValueElement = new VisualElement();
+                keyValueElement.AddToClassList("dictionary-field__item__key-value-element");
                 box.Add(keyValueElement);
 
-                keyField = new GenericField(key, keyType, KeyName) { name = "key-field" };
+                keyField = new GenericField(key, keyType, KeyName);
+                keyField.AddToClassList("dictionary-field__item__key-field");
                 keyField.OnValueChanged += SetKey;
                 keyValueElement.Add(keyField);
 
-                valueField = new GenericField(value, valueType, ValueName) { name = "value-field" };
+                valueField = new GenericField(value, valueType, ValueName);
+                valueField.AddToClassList("dictionary-field__item__value-field");
                 valueField.OnValueChanged += SetValue;
                 keyValueElement.Add(valueField);
 
-                var closeButton = new Button(() => OnClose?.Invoke())
-                {
-                    name = "close-button",
-                    text = "X"
-                };
+                var closeButton = new Button(() => OnClose?.Invoke()) { text = "X" };
+                closeButton.AddToClassList("dictionary-field__item__close-button");
+                
                 box.Add(closeButton);
                 Add(box);
             }

--- a/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -17,6 +16,9 @@ namespace Alchemy.Editor.Elements
 
         public GenericField(object obj, Type type, string label,bool isDelayed = false)
         {
+            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/GenericField-Styles");
+            styleSheets.Add(styleSheet);
+
             Build(obj, type, label, isDelayed);
             GUIHelper.ScheduleAdjustLabelWidth(this);
         }
@@ -28,23 +30,8 @@ namespace Alchemy.Editor.Elements
             // Add [Create...] button
             if (obj == null && !typeof(UnityEngine.Object).IsAssignableFrom(type))
             {
-                var nullLabelElement = new VisualElement()
-                {
-                    style = {
-                        width = Length.Percent(100f),
-                        height = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing,
-                        paddingLeft = 3f,
-                        flexDirection = FlexDirection.Row
-                    }
-                };
-
-                nullLabelElement.Add(new Label(label + " (Null)")
-                {
-                    style = {
-                        flexGrow = 1f,
-                        unityTextAlign = TextAnchor.MiddleLeft
-                    }
-                });
+                var nullLabelElement = new VisualElement { name = "null-label-element" };
+                nullLabelElement.Add(new Label(label + " (Null)") { name = "null-label" });
 
                 // TODO: support polymorphism
                 if (type == typeof(string))
@@ -56,6 +43,7 @@ namespace Alchemy.Editor.Elements
                         OnValueChanged?.Invoke(instance);
                     })
                     {
+                        name = "string-create-button",
                         text = CreateButtonText
                     });
                 }
@@ -68,6 +56,7 @@ namespace Alchemy.Editor.Elements
                         OnValueChanged?.Invoke(instance);
                     })
                     {
+                        name = "nullable-create-button",
                         text = CreateButtonText
                     });
                 }
@@ -80,6 +69,7 @@ namespace Alchemy.Editor.Elements
                         OnValueChanged?.Invoke(instance);
                     })
                     {
+                        name = "default-create-button",
                         text = CreateButtonText
                     });
                 }

--- a/Alchemy/Assets/Alchemy/Editor/Elements/HashMapFieldBase.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/HashMapFieldBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -10,19 +9,19 @@ namespace Alchemy.Editor.Elements
     {
         public HashMapFieldBase(object collection, string label)
         {
+            styleSheets.Add(Resources.Load<StyleSheet>("Elements/HashMapFieldBase-Styles"));
+            
             this.collection = collection;
 
-            var foldout = new Foldout()
-            {
-                text = label
-            };
+            var foldout = new Foldout { text = label };
+            foldout.AddToClassList("alchemy-hash_map_base-foldout");
             Add(foldout);
-            foldout.Q<Label>().style.unityFontStyleAndWeight = FontStyle.Bold;
-
-            contents = new();
+            
+            contents = new() { name = "contents" };
+            contents.AddToClassList("alchemy-hash_map_base-contents");
             foldout.Add(contents);
 
-            inputForm = new();
+            inputForm = new() { name = "input-form" };
             foldout.Add(inputForm);
 
             addButton = new Button(() =>
@@ -30,16 +29,11 @@ namespace Alchemy.Editor.Elements
                 if (isInputting) EndInput();
                 else StartInput();
             })
-            {
-                style = {
-                    alignSelf = Align.FlexEnd,
-                    minWidth = 60f
-                },
-                text = "+ Add"
-            };
+            { text = "+ Add" };
+            
+            addButton.AddToClassList("alchemy-hash_map_base-add_button");
+            
             foldout.Add(addButton);
-
-            foldout.Add(new VisualElement() { style = { minHeight = 4f } });
 
             Rebuild();
         }
@@ -137,12 +131,8 @@ namespace Alchemy.Editor.Elements
             if (i == 0)
             {
                 var box = new Box();
-                box.style.minHeight = EditorGUIUtility.singleLineHeight * 1.2f;
-                box.style.paddingLeft = 6f;
-
                 var label = new Label(CollectionTypeName + " is empty.");
-                label.style.height = Length.Percent(100f);
-                label.style.unityTextAlign = TextAnchor.MiddleLeft;
+              
                 box.Add(label);
 
                 inputForm.Add(box);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/HashMapFieldBase.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/HashMapFieldBase.cs
@@ -7,21 +7,24 @@ namespace Alchemy.Editor.Elements
 {
     public abstract class HashMapFieldBase : VisualElement
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/HashMapFieldBase-Styles");
+        
         public HashMapFieldBase(object collection, string label)
         {
-            styleSheets.Add(Resources.Load<StyleSheet>("Elements/HashMapFieldBase-Styles"));
+            styleSheets.Add(_styleSheet);
             
             this.collection = collection;
 
             var foldout = new Foldout { text = label };
-            foldout.AddToClassList("alchemy-hash_map_base-foldout");
+            foldout.AddToClassList("hash-map-field-base__foldout");
             Add(foldout);
-            
-            contents = new() { name = "contents" };
-            contents.AddToClassList("alchemy-hash_map_base-contents");
+
+            contents = new();
+            contents.AddToClassList("hash-map-field-base__contents");
             foldout.Add(contents);
 
-            inputForm = new() { name = "input-form" };
+            inputForm = new();
+            inputForm.AddToClassList("hash-map-field-base__input-form");
             foldout.Add(inputForm);
 
             addButton = new Button(() =>
@@ -30,8 +33,7 @@ namespace Alchemy.Editor.Elements
                 else StartInput();
             })
             { text = "+ Add" };
-            
-            addButton.AddToClassList("alchemy-hash_map_base-add_button");
+            addButton.AddToClassList("hash-map-field-base__add-button");
             
             foldout.Add(addButton);
 
@@ -131,8 +133,11 @@ namespace Alchemy.Editor.Elements
             if (i == 0)
             {
                 var box = new Box();
+                box.AddToClassList("hash-map-field-base__empty-box");
+                
                 var label = new Label(CollectionTypeName + " is empty.");
-              
+                label.AddToClassList("hash-map-field-base__empty-label");
+                
                 box.Add(label);
 
                 inputForm.Add(box);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/HashSetField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/HashSetField.cs
@@ -1,4 +1,3 @@
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -6,7 +5,10 @@ namespace Alchemy.Editor.Elements
 {
     public sealed class HashSetField : HashMapFieldBase
     {
-        public HashSetField(object collection, string label) : base(collection, label) { }
+        public HashSetField(object collection, string label) : base(collection, label)
+        {
+            Resources.Load<StyleSheet>("Elements/HashSetField-Styles");
+        }
 
         public override string CollectionTypeName => "HashSet";
 
@@ -44,19 +46,13 @@ namespace Alchemy.Editor.Elements
         {
             public Item(object collection, object elementObj, string label)
             {
-                var box = new Box()
-                {
-                    style = {
-                        marginBottom = 3.5f,
-                        marginRight = -2f,
-                        flexDirection = FlexDirection.Row
-                    }
-                };
+                AddToClassList("alchemy-hash_set_item");
+                
+                var box = new Box();
 
                 var valueType = elementObj == null ? collection.GetType().GenericTypeArguments[0] : elementObj.GetType();
 
                 inputField = new GenericField(elementObj, valueType, label);
-                inputField.style.flexGrow = 1f;
                 inputField.OnValueChanged += x =>
                 {
                     value = x;
@@ -66,13 +62,8 @@ namespace Alchemy.Editor.Elements
 
                 var closeButton = new Button(() => OnClose?.Invoke())
                 {
-                    style = {
-                        width = EditorGUIUtility.singleLineHeight,
-                        height = EditorGUIUtility.singleLineHeight,
-                        unityFontStyleAndWeight = FontStyle.Bold,
-                        fontSize = 10f
-                    },
-                    text = "X",
+                    name = "close-button",
+                    text = "X"
                 };
                 box.Add(closeButton);
                 Add(box);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/HashSetField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/HashSetField.cs
@@ -5,9 +5,11 @@ namespace Alchemy.Editor.Elements
 {
     public sealed class HashSetField : HashMapFieldBase
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/HashSetField-Styles");
+        
         public HashSetField(object collection, string label) : base(collection, label)
         {
-            Resources.Load<StyleSheet>("Elements/HashSetField-Styles");
+            styleSheets.Add(_styleSheet);
         }
 
         public override string CollectionTypeName => "HashSet";

--- a/Alchemy/Assets/Alchemy/Editor/Elements/HashSetField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/HashSetField.cs
@@ -46,13 +46,15 @@ namespace Alchemy.Editor.Elements
         {
             public Item(object collection, object elementObj, string label)
             {
-                AddToClassList("alchemy-hash_set_item");
+                AddToClassList("hash-set-field__item");
                 
                 var box = new Box();
+                box.AddToClassList("hash-set-field__item__box");
 
                 var valueType = elementObj == null ? collection.GetType().GenericTypeArguments[0] : elementObj.GetType();
 
                 inputField = new GenericField(elementObj, valueType, label);
+                inputField.AddToClassList("hash-set-field__item__input-field");
                 inputField.OnValueChanged += x =>
                 {
                     value = x;
@@ -65,6 +67,8 @@ namespace Alchemy.Editor.Elements
                     name = "close-button",
                     text = "X"
                 };
+                closeButton.AddToClassList("hash-set-field__item__close-button");
+                
                 box.Add(closeButton);
                 Add(box);
             }

--- a/Alchemy/Assets/Alchemy/Editor/Elements/InlineEditorObjectField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/InlineEditorObjectField.cs
@@ -4,6 +4,7 @@ using UnityEngine.UIElements;
 using UnityEditor;
 using UnityEditor.UIElements;
 using Alchemy.Inspector;
+using UnityEngine;
 
 namespace Alchemy.Editor.Elements
 {
@@ -14,6 +15,8 @@ namespace Alchemy.Editor.Elements
     {
         public InlineEditorObjectField(SerializedProperty property, Type type)
         {
+            styleSheets.Add(Resources.Load<StyleSheet>("Elements/InlineEditor-Styles"));
+            
             Assert.IsTrue(property.propertyType == SerializedPropertyType.ObjectReference);
 
             style.minHeight = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
@@ -30,13 +33,12 @@ namespace Alchemy.Editor.Elements
 
             field = new ObjectField()
             {
+                name = "object-field",
                 label = ObjectNames.NicifyVariableName(property.displayName),
                 objectType = type,
                 allowSceneObjects = !property.GetFieldInfo().HasCustomAttribute<AssetsOnlyAttribute>(),
                 value = property.objectReferenceValue
             };
-            field.style.position = Position.Absolute;
-            field.style.width = Length.Percent(100f);
             GUIHelper.ScheduleAdjustLabelWidth(field);
 
             OnPropertyChanged(property);
@@ -96,7 +98,6 @@ namespace Alchemy.Editor.Elements
             toggle.style.display = isNull ? DisplayStyle.None : DisplayStyle.Flex;
             if (!isNull)
             {
-                foldout.Add(new VisualElement() { style = { height = EditorGUIUtility.standardVerticalSpacing } });
                 var so = new SerializedObject(property.objectReferenceValue);
                 InspectorHelper.BuildElements(so, foldout, so.targetObject, name => so.FindProperty(name));
                 this.Bind(so);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/InlineEditorObjectField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/InlineEditorObjectField.cs
@@ -13,18 +13,19 @@ namespace Alchemy.Editor.Elements
     /// </summary>
     public sealed class InlineEditorObjectField : BindableElement
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/InlineEditor-Styles");
+            
         public InlineEditorObjectField(SerializedProperty property, Type type)
         {
-            styleSheets.Add(Resources.Load<StyleSheet>("Elements/InlineEditor-Styles"));
+            styleSheets.Add(_styleSheet);
             
             Assert.IsTrue(property.propertyType == SerializedPropertyType.ObjectReference);
 
             style.minHeight = EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
 
-            foldout = new Foldout()
-            {
-                text = ObjectNames.NicifyVariableName(property.displayName)
-            };
+            foldout = new Foldout { text = ObjectNames.NicifyVariableName(property.displayName) };
+            foldout.AddToClassList("inline-editor__foldout");
+            
             var toggle = foldout.Q<Toggle>();
             var clickable = InternalAPIHelper.GetClickable(toggle);
             InternalAPIHelper.SetAcceptClicksIfDisabled(clickable, true);
@@ -33,12 +34,13 @@ namespace Alchemy.Editor.Elements
 
             field = new ObjectField()
             {
-                name = "object-field",
                 label = ObjectNames.NicifyVariableName(property.displayName),
                 objectType = type,
                 allowSceneObjects = !property.GetFieldInfo().HasCustomAttribute<AssetsOnlyAttribute>(),
                 value = property.objectReferenceValue
             };
+            field.AddToClassList("inline-editor__object-field");
+            
             GUIHelper.ScheduleAdjustLabelWidth(field);
 
             OnPropertyChanged(property);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/InlineEditorObjectField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/InlineEditorObjectField.cs
@@ -40,6 +40,8 @@ namespace Alchemy.Editor.Elements
                 value = property.objectReferenceValue
             };
             field.AddToClassList("inline-editor__object-field");
+
+            SetSelectors(property.objectReferenceValue);
             
             GUIHelper.ScheduleAdjustLabelWidth(field);
 
@@ -49,10 +51,18 @@ namespace Alchemy.Editor.Elements
                 property.objectReferenceValue = x.newValue;
                 property.serializedObject.ApplyModifiedProperties();
                 OnPropertyChanged(property);
+
+                SetSelectors(property.objectReferenceValue);
             });
 
             Add(foldout);
             Add(field);
+            
+            void SetSelectors(UnityEngine.Object propertyObjectReferenceValue)
+            {
+                AddToClassList(propertyObjectReferenceValue == null ? "inline-editor--empty" : "inline-editor--populated");
+                RemoveFromClassList(propertyObjectReferenceValue != null ? "inline-editor--empty" : "inline-editor--populated");
+            }
         }
 
         readonly Foldout foldout;

--- a/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Alchemy.Editor.Elements
@@ -10,15 +11,16 @@ namespace Alchemy.Editor.Elements
 
         public MethodButton(object target, MethodInfo methodInfo)
         {
+            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/MethodButton-Styles");
+
+            styleSheets.Add(styleSheet);
+
             var parameters = methodInfo.GetParameters();
 
             // Create parameterless button
             if (parameters.Length == 0)
             {
-                button = new Button(() => methodInfo.Invoke(target, null))
-                {
-                    text = methodInfo.Name
-                };
+                button = new Button(() => methodInfo.Invoke(target, null)) { text = methodInfo.Name };
                 Add(button);
                 return;
             }
@@ -28,30 +30,17 @@ namespace Alchemy.Editor.Elements
             var box = new HelpBox();
             Add(box);
 
-            foldout = new Foldout()
+            foldout = new Foldout
             {
                 text = methodInfo.Name,
-                value = false,
-                style = {
-                    flexGrow = 1f
-                }
+                value = false
             };
             InternalAPIHelper.SetAcceptClicksIfDisabled(
                 InternalAPIHelper.GetClickable(foldout.Q<Toggle>()), true
             );
 
-            button = new Button(() => methodInfo.Invoke(target, parameterObjects))
-            {
-                text = ButtonLabelText,
-                style = {
-                    position = Position.Absolute,
-                    right = 1f,
-                    top = 1.5f,
-                    width = 100f
-                }
-            };
-
-            box.Add(new VisualElement() { style = { width = 12f } });
+            button = new Button(() => methodInfo.Invoke(target, parameterObjects)) { text = ButtonLabelText };
+            
             box.Add(foldout);
             box.Add(button);
 
@@ -62,7 +51,6 @@ namespace Alchemy.Editor.Elements
                 parameterObjects[index] = TypeHelper.CreateDefaultInstance(parameter.ParameterType);
                 var element = new GenericField(parameterObjects[index], parameter.ParameterType, ObjectNames.NicifyVariableName(parameter.Name));
                 element.OnValueChanged += x => parameterObjects[index] = x;
-                element.style.paddingRight = 4f;
                 foldout.Add(element);
             }
         }

--- a/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
@@ -7,20 +7,23 @@ namespace Alchemy.Editor.Elements
 {
     public sealed class MethodButton : VisualElement
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/MethodButton-Styles");
+        
         const string ButtonLabelText = "Invoke";
 
         public MethodButton(object target, MethodInfo methodInfo)
         {
-            StyleSheet styleSheet = Resources.Load<StyleSheet>("Elements/MethodButton-Styles");
+            styleSheets.Add(_styleSheet);
 
-            styleSheets.Add(styleSheet);
-
+            AddToClassList("method-button");
+            
             var parameters = methodInfo.GetParameters();
 
             // Create parameterless button
             if (parameters.Length == 0)
             {
                 button = new Button(() => methodInfo.Invoke(target, null)) { text = methodInfo.Name };
+                button.AddToClassList("method-button__button");
                 Add(button);
                 return;
             }
@@ -28,6 +31,8 @@ namespace Alchemy.Editor.Elements
             var parameterObjects = new object[parameters.Length];
 
             var box = new HelpBox();
+            box.AddToClassList("method-button__help-box");
+            
             Add(box);
 
             foldout = new Foldout
@@ -35,11 +40,14 @@ namespace Alchemy.Editor.Elements
                 text = methodInfo.Name,
                 value = false
             };
+            foldout.AddToClassList("method-button__foldout");
+            
             InternalAPIHelper.SetAcceptClicksIfDisabled(
                 InternalAPIHelper.GetClickable(foldout.Q<Toggle>()), true
             );
 
             button = new Button(() => methodInfo.Invoke(target, parameterObjects)) { text = ButtonLabelText };
+            button.AddToClassList("method-button__parameter-button");
             
             box.Add(foldout);
             box.Add(button);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/SerializeReferenceField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/SerializeReferenceField.cs
@@ -16,6 +16,8 @@ namespace Alchemy.Editor.Elements
     {
         public SerializeReferenceField(SerializedProperty property)
         {
+            styleSheets.Add(Resources.Load<StyleSheet>("Elements/SerializeReferenceField-Styles"));
+            
             Assert.IsTrue(property.propertyType == SerializedPropertyType.ManagedReference);
 
             style.flexDirection = FlexDirection.Row;
@@ -25,8 +27,8 @@ namespace Alchemy.Editor.Elements
             {
                 text = ObjectNames.NicifyVariableName(property.displayName)
             };
-            foldout.style.flexGrow = 1f;
             foldout.BindProperty(property);
+            
             Add(foldout);
 
             buttonContainer = new IMGUIContainer(() =>
@@ -94,10 +96,7 @@ namespace Alchemy.Editor.Elements
                 buttonContainer.style.width = GUIHelper.CalculateFieldWidth(buttonContainer, visualTree) -
                     (buttonContainer.GetFirstAncestorOfType<Foldout>() != null ? 18f : 0f);
             });
-
-            buttonContainer.style.position = Position.Absolute;
-            buttonContainer.style.top = EditorGUIUtility.standardVerticalSpacing * 0.5f;
-            buttonContainer.style.right = 0f;
+            
             Add(buttonContainer);
 
             Rebuild(property);

--- a/Alchemy/Assets/Alchemy/Editor/Elements/SerializeReferenceField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/SerializeReferenceField.cs
@@ -14,9 +14,11 @@ namespace Alchemy.Editor.Elements
     /// </summary>
     public sealed class SerializeReferenceField : VisualElement
     {
+        private readonly StyleSheet _styleSheet = Resources.Load<StyleSheet>("Elements/SerializeReferenceField-Styles");
+            
         public SerializeReferenceField(SerializedProperty property)
         {
-            styleSheets.Add(Resources.Load<StyleSheet>("Elements/SerializeReferenceField-Styles"));
+            styleSheets.Add(_styleSheet);
             
             Assert.IsTrue(property.propertyType == SerializedPropertyType.ManagedReference);
 
@@ -27,6 +29,7 @@ namespace Alchemy.Editor.Elements
             {
                 text = ObjectNames.NicifyVariableName(property.displayName)
             };
+            foldout.AddToClassList("serialize-reference-field__foldout");
             foldout.BindProperty(property);
             
             Add(foldout);
@@ -84,6 +87,7 @@ namespace Alchemy.Editor.Elements
                     dropdown.Show(position);
                 }
             });
+            buttonContainer.AddToClassList("serialize-reference-field__pick-reference-button");
 
             schedule.Execute(() =>
             {

--- a/Alchemy/Assets/Alchemy/Editor/Elements/SerializeReferenceField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/SerializeReferenceField.cs
@@ -127,6 +127,9 @@ namespace Alchemy.Editor.Elements
             }
 
             this.Bind(property.serializedObject);
+            
+            AddToClassList(property.managedReferenceValue == null ? "serialize-reference-field--empty" : "serialize-reference-field--populated");
+            RemoveFromClassList(property.managedReferenceValue != null ? "serialize-reference-field--empty" : "serialize-reference-field--populated");
         }
     }
 }

--- a/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
@@ -190,5 +190,17 @@ namespace Alchemy.Editor
             visualElement.style.minWidth = value;
             visualElement.style.width = value;
         }
+        
+        public static void ModifyChildFoldouts(VisualElement element, string className)
+        {
+            element.schedule.Execute(() =>
+            {
+                foreach (var foldout in element.Query<Foldout>().Build())
+                {
+                    if (foldout.parent == element || foldout.parent.parent == element)
+                        foldout.AddToClassList(className);
+                }
+            });
+        }
     }
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9dcf9c67b1d94ed2a2b6f2b9bcdc21c7
+timeCreated: 1722592974

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b3b507e35c734290b848fdebd276ab4a
+timeCreated: 1722592986

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss
@@ -1,0 +1,18 @@
+HelpBox.alchemy-group_attribute-box_group_drawer-help_box {
+    width: 100%;
+    margin-top: 3px;
+    padding-bottom: 3px;
+    padding-right: 5px;
+    padding-left: 3px;
+    flex-direction: column;
+    margin-left: 0;
+}
+
+HelpBox.alchemy-group_attribute-box_group_drawer-help_box > Label.unity-help-box__label {
+    top: 2px;
+    left: 2px;
+    font-size: 12px;
+    min-height: 18px;
+    -unity-font-style: bold;
+    align-self: stretch;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss
@@ -1,4 +1,4 @@
-HelpBox.alchemy-group_attribute-box_group_drawer-help_box {
+.box-group__help-box {
     width: 100%;
     margin-top: 3px;
     padding-bottom: 3px;
@@ -8,7 +8,7 @@ HelpBox.alchemy-group_attribute-box_group_drawer-help_box {
     margin-left: 0;
 }
 
-HelpBox.alchemy-group_attribute-box_group_drawer-help_box > Label.unity-help-box__label {
+.box-group__help-box > Label.unity-help-box__label {
     top: 2px;
     left: 2px;
     font-size: 12px;

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss
@@ -16,3 +16,10 @@
     -unity-font-style: bold;
     align-self: stretch;
 }
+
+.box-group__help-box__child-foldout {
+}
+
+.box-group__help-box__child-foldout > Toggle {
+    margin-left: 0;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/BoxGroupDrawer-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 117704c2b443e014095f10d11b9f210f
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/ClassField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/ClassField-Styles.uss
@@ -1,0 +1,3 @@
+ReflectionField.alchemy-class_field-element {
+    width: 100%;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/ClassField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/ClassField-Styles.uss
@@ -1,3 +1,3 @@
-ReflectionField.alchemy-class_field-element {
+.class-field__reflection-field {
     width: 100%;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/ClassField-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/ClassField-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46dce550910e1d240b5dfb9ee6393add
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/DictionaryField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/DictionaryField-Styles.uss
@@ -1,0 +1,21 @@
+Item.alchemy-dictionary_item > Box {
+    margin-bottom: 3.5px;
+    margin-right: -2px;
+    flex-direction: row;
+}
+
+Item.alchemy-dictionary_item > Box > #key-value-element {
+    flex-direction: column;
+    flex-grow: 1;
+}
+
+Item.alchemy-dictionary_item > Box > #key-value-element > GenericField {
+    flex-grow: 1;
+}
+
+Item.alchemy-dictionary_item > Box > Button#close-button {
+    width: 18px;
+    height: 18px;
+    -unity-font-style: bold;
+    font-size: 10px;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/DictionaryField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/DictionaryField-Styles.uss
@@ -1,21 +1,18 @@
-Item.alchemy-dictionary_item > Box {
+.dictionary-field__item__box {
     margin-bottom: 3.5px;
     margin-right: -2px;
     flex-direction: row;
 }
 
-Item.alchemy-dictionary_item > Box > #key-value-element {
+.dictionary-field__item__key-value-element {
     flex-direction: column;
     flex-grow: 1;
 }
 
-Item.alchemy-dictionary_item > Box > #key-value-element > GenericField {
-    flex-grow: 1;
-}
-
-Item.alchemy-dictionary_item > Box > Button#close-button {
+.dictionary-field__item__close-button {
     width: 18px;
     height: 18px;
     -unity-font-style: bold;
     font-size: 10px;
+    margin-left: 6px;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/DictionaryField-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/DictionaryField-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43783c92a5e44cd448d8779a4ef2ad75
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/FoldoutGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/FoldoutGroupDrawer-Styles.uss
@@ -1,0 +1,3 @@
+Foldout.alchemy-group_attribute-foldout_group_drawer-foldout {
+    width: 100%;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/FoldoutGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/FoldoutGroupDrawer-Styles.uss
@@ -1,3 +1,3 @@
-Foldout.alchemy-group_attribute-foldout_group_drawer-foldout {
+.foldout-group__foldout {
     width: 100%;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/FoldoutGroupDrawer-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/FoldoutGroupDrawer-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b17ba45088bebc4fa28f6dafc3ebd06
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GenericField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GenericField-Styles.uss
@@ -1,0 +1,11 @@
+GenericField > #null-label-element {
+    width: 100%;
+    height: 20px;
+    padding-left: 3px;
+    flex-direction: row;
+}
+
+GenericField > #null-label-element > Label#null-label {
+    flex-grow: 1;
+    -unity-text-align: middle-left;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GenericField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GenericField-Styles.uss
@@ -1,11 +1,11 @@
-GenericField > #null-label-element {
+.generic-field__nullable-area {
     width: 100%;
     height: 20px;
     padding-left: 3px;
     flex-direction: row;
 }
 
-GenericField > #null-label-element > Label#null-label {
+.generic-field__nullable-area__label {
     flex-grow: 1;
     -unity-text-align: middle-left;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GenericField-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GenericField-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ac1260ce4a7de944913341fc812795b
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss
@@ -1,0 +1,7 @@
+Box.alchemy-group_attribute-group_drawer-box {
+    width: 100%;
+    margin-top: 3px;
+    padding-bottom: 2px;
+    padding-right: 2px;
+    padding-left: 1px;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss
@@ -1,4 +1,4 @@
-Box.alchemy-group_attribute-group_drawer-box {
+.group__box {
     width: 100%;
     margin-top: 3px;
     padding-bottom: 2px;

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss
@@ -5,3 +5,10 @@
     padding-right: 2px;
     padding-left: 1px;
 }
+
+.group__box__child-foldout {
+}
+
+.group__box__child-foldout > Toggle {
+    margin-left: 0;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/GroupDrawer-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d6b242beb0c9604a8391767034d571f
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashMapFieldBase-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashMapFieldBase-Styles.uss
@@ -1,0 +1,22 @@
+Button.alchemy-hash_map_base-add_button {
+    min-width: 60px;
+    align-items: flex-end;
+}
+
+Foldout.alchemy-hash_map_base-foldout > Toggle > VisualElement > Label {
+    -unity-font-style: bold;
+}
+
+Foldout.alchemy-hash_map_base-foldout > #unity-content {
+    margin-bottom: 4px;
+}
+
+Foldout.alchemy-hash_map_base-foldout > #input-form > Box {
+    min-height: 26px;
+    padding-left: 6px;
+}
+
+Foldout.alchemy-hash_map_base-foldout > #input-form > Box > Label {
+    width: 100%;
+    -unity-text-align: middle-left;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashMapFieldBase-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashMapFieldBase-Styles.uss
@@ -1,22 +1,26 @@
-Button.alchemy-hash_map_base-add_button {
+Foldout.hash-map-field-base__foldout > Toggle > VisualElement > Label {
+    -unity-font-style: bold;
+}
+
+Foldout.hash-map-field-base__foldout > #unity-content {
+    margin-bottom: 4px;
+}
+
+.hash-map-field-base__add-button {
     min-width: 60px;
     align-items: flex-end;
 }
 
-Foldout.alchemy-hash_map_base-foldout > Toggle > VisualElement > Label {
-    -unity-font-style: bold;
-}
-
-Foldout.alchemy-hash_map_base-foldout > #unity-content {
-    margin-bottom: 4px;
-}
-
-Foldout.alchemy-hash_map_base-foldout > #input-form > Box {
+.hash-map-field-base__input-form > Box {
     min-height: 26px;
     padding-left: 6px;
 }
 
-Foldout.alchemy-hash_map_base-foldout > #input-form > Box > Label {
+.hash-map-field-base__input-form > Box > Label {
     width: 100%;
     -unity-text-align: middle-left;
+}
+
+.hash-map-field-base__empty-box {
+    padding-top: 4px;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashMapFieldBase-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashMapFieldBase-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b12372e7fba421498abd9feb71f070a
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashSetField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashSetField-Styles.uss
@@ -1,0 +1,16 @@
+Item.alchemy-hash_set_item > Box {
+    margin-right: -2px;
+    margin-bottom: 3.5px;
+    flex-direction: row;
+}
+
+Item.alchemy-hash_set_item > Box > GenericField {
+    flex-grow: 1;
+}
+
+Item.alchemy-hash_set_item > Box > Button#close-button {
+    width: 18px;
+    height: 18px;
+    -unity-font-style: bold;
+    font-size: 10px;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashSetField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashSetField-Styles.uss
@@ -1,14 +1,10 @@
-Item.alchemy-hash_set_item > Box {
+.hash-set-field__item__box {
     margin-right: -2px;
     margin-bottom: 3.5px;
     flex-direction: row;
 }
 
-Item.alchemy-hash_set_item > Box > GenericField {
-    flex-grow: 1;
-}
-
-Item.alchemy-hash_set_item > Box > Button#close-button {
+.hash-set-field__item__close-button {
     width: 18px;
     height: 18px;
     -unity-font-style: bold;

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashSetField-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HashSetField-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd286bd8c2d9b0441b75501a60eac224
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss
@@ -1,0 +1,4 @@
+VisualElement.alchemy-group_attribute-horizontal_group_drawer-visual_element {
+    width: 100%;
+    flex-direction: row;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss
@@ -1,4 +1,4 @@
-VisualElement.alchemy-group_attribute-horizontal_group_drawer-visual_element {
+.horizontal-group__main-element {
     width: 100%;
     flex-direction: row;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss
@@ -2,3 +2,6 @@
     width: 100%;
     flex-direction: row;
 }
+
+.horizontal-group__property-field__label {
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/HorizontalGroupDrawer-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b28d225d83221f4a8b023a8c7b91e67
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/InlineEditor-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/InlineEditor-Styles.uss
@@ -1,0 +1,8 @@
+InlineEditorObjectField > ObjectField#object-field {
+    position: absolute;
+    width: 100%;
+}
+
+InlineEditorObjectField > Foldout > #unity-content {
+    padding-top: 2px;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/InlineEditor-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/InlineEditor-Styles.uss
@@ -1,8 +1,8 @@
-InlineEditorObjectField > ObjectField#object-field {
+.inline-editor__object-field {
     position: absolute;
     width: 100%;
 }
 
-InlineEditorObjectField > Foldout > #unity-content {
+.inline-editor__foldout > Foldout > #unity-content {
     padding-top: 2px;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/InlineEditor-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/InlineEditor-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aaa4afc631a4af34fb865228740cc721
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/MethodButton-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/MethodButton-Styles.uss
@@ -1,0 +1,27 @@
+MethodButton > HelpBox {
+    margin-right: 0;
+    margin-left: 0;
+}
+
+MethodButton > HelpBox > Button {
+    position: absolute;
+    top: 1.5px;
+    right: 1px;
+    width: 100px;
+}
+
+MethodButton > HelpBox > Foldout {
+    flex-grow: 1;
+}
+
+MethodButton > HelpBox > Foldout > Toggle {
+    margin-left: 0;
+}
+
+MethodButton > HelpBox > Foldout > #unity-content {
+    margin-top: 2px;
+}
+
+MethodButton > HelpBox > Foldout > GenericField {
+    padding-right: 4px;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/MethodButton-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/MethodButton-Styles.uss
@@ -1,27 +1,27 @@
-MethodButton > HelpBox {
+.method-button__help-box {
     margin-right: 0;
     margin-left: 0;
 }
 
-MethodButton > HelpBox > Button {
+.method-button__parameter-button {
     position: absolute;
     top: 1.5px;
     right: 1px;
     width: 100px;
 }
 
-MethodButton > HelpBox > Foldout {
+.method-button__foldout {
     flex-grow: 1;
 }
 
-MethodButton > HelpBox > Foldout > Toggle {
+Foldout.method-button__foldout > Toggle {
     margin-left: 0;
 }
 
-MethodButton > HelpBox > Foldout > #unity-content {
+Foldout.method-button__foldout > #unity-content {
     margin-top: 2px;
 }
 
-MethodButton > HelpBox > Foldout > GenericField {
+Foldout.method-button__foldout > GenericField {
     padding-right: 4px;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/MethodButton-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/MethodButton-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1c473f1a5a2d5d4eb405d92395d3fe1
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/PreviewDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/PreviewDrawer-Styles.uss
@@ -1,0 +1,32 @@
+Image.alchemy-attribute-preview_drawer-image {
+    width: 40px;
+    height: 40px;
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    border-left-color: rgb(13, 13, 13);
+    border-right-color: rgb(13, 13, 13);
+    border-bottom-color: rgb(13, 13, 13);
+    border-top-color: rgb(13, 13, 13);
+    margin-top: 2px;
+    margin-bottom: 4px;
+    align-self: flex-end;
+    -unity-background-scale-mode: scale-to-fit;
+}
+
+Image.alchemy-attribute-preview_drawer-image:hover {
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+Image.alchemy-attribute-preview_drawer-image.align-right {
+    align-self: flex-end;
+}
+
+Image.alchemy-attribute-preview_drawer-image.align-center {
+    align-self: center;
+}
+
+Image.alchemy-attribute-preview_drawer-image.align-left {
+    align-self: flex-start;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/PreviewDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/PreviewDrawer-Styles.uss
@@ -1,4 +1,4 @@
-Image.alchemy-attribute-preview_drawer-image {
+.preview-attribute__image {
     width: 40px;
     height: 40px;
     border-top-width: 1px;
@@ -15,18 +15,18 @@ Image.alchemy-attribute-preview_drawer-image {
     -unity-background-scale-mode: scale-to-fit;
 }
 
-Image.alchemy-attribute-preview_drawer-image:hover {
+.preview-attribute__image:hover {
     background-color: rgba(0, 0, 0, 0.2);
 }
 
-Image.alchemy-attribute-preview_drawer-image.align-right {
+.preview-attribute__image.preview-attribute__image--align-right {
     align-self: flex-end;
 }
 
-Image.alchemy-attribute-preview_drawer-image.align-center {
+.preview-attribute__image.preview-attribute__image--align-center {
     align-self: center;
 }
 
-Image.alchemy-attribute-preview_drawer-image.align-left {
+.preview-attribute__image.preview-attribute__image--align-left {
     align-self: flex-start;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/PreviewDrawer-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/PreviewDrawer-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69c6b4cc64394494dbba0a8c3ecd4948
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/SerializeReferenceField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/SerializeReferenceField-Styles.uss
@@ -1,0 +1,13 @@
+SerializeReferenceField > .unity-imgui-container {
+    position: absolute;
+    right: 2px;
+    top: 0;
+}
+
+SerializeReferenceField > Foldout {
+    flex-grow: 1;
+}
+
+SerializeReferenceField > Foldout > #unity-content {
+    padding-right: 4px;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/SerializeReferenceField-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/SerializeReferenceField-Styles.uss
@@ -1,13 +1,13 @@
-SerializeReferenceField > .unity-imgui-container {
+.serialize-reference-field__pick-reference-button {
     position: absolute;
     right: 2px;
     top: 0;
 }
 
-SerializeReferenceField > Foldout {
+.serialize-reference-field__foldout {
     flex-grow: 1;
 }
 
-SerializeReferenceField > Foldout > #unity-content {
+Foldout.serialize-reference-field__foldout > #unity-content {
     padding-right: 4px;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/SerializeReferenceField-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/SerializeReferenceField-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91582b4ac42c4aa428921592952fda23
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss
@@ -1,0 +1,23 @@
+HelpBox.alchemy-group_attribute-tab_group_drawer-help_box {
+    width: 100%;
+    margin-top: 3px;
+    flex-direction: column;
+    overflow: hidden;
+    padding-top: 3px;
+    padding-right: 3px;
+    padding-left: 3px;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+HelpBox.alchemy-group_attribute-tab_group_drawer-help_box > IMGUIContainer {
+    align-self: stretch;
+}
+
+HelpBox.alchemy-group_attribute-tab_group_drawer-help_box > #page-root {
+    width: 100%;
+}
+
+HelpBox.alchemy-group_attribute-tab_group_drawer-help_box > VisualElement.tab-page {
+    width: 100%;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss
@@ -1,4 +1,4 @@
-HelpBox.alchemy-group_attribute-tab_group_drawer-help_box {
+.tab-group__help-box {
     width: 100%;
     margin-top: 3px;
     flex-direction: column;
@@ -10,14 +10,14 @@ HelpBox.alchemy-group_attribute-tab_group_drawer-help_box {
     margin-right: 0;
 }
 
-HelpBox.alchemy-group_attribute-tab_group_drawer-help_box > IMGUIContainer {
+.tab-group__tab-section {
     align-self: stretch;
 }
 
-HelpBox.alchemy-group_attribute-tab_group_drawer-help_box > #page-root {
+.tab-group__page-root {
     width: 100%;
 }
 
-HelpBox.alchemy-group_attribute-tab_group_drawer-help_box > VisualElement.tab-page {
+.tab-group__tab-page {
     width: 100%;
 }

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss
@@ -21,3 +21,10 @@
 .tab-group__tab-page {
     width: 100%;
 }
+
+.tab-group__tab-page__child-foldout {
+}
+
+.tab-group__tab-page__child-foldout > Toggle {
+    margin-left: 0;
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TabGroupDrawer-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13a48c1b8ba62f942b4cbb2aae034159
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TitleDrawer-Attribute-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TitleDrawer-Attribute-Styles.uss
@@ -1,0 +1,13 @@
+Label.alchemy-attribute-title_drawer-title {
+    -unity-font-style: bold;
+    padding-left: 3px;
+    margin-top: 4px;
+    margin-bottom: -2px;
+}
+
+Label.alchemy-attribute-title_drawer-subtitle {
+    font-size: 10px;
+    padding-left: 4.5px;
+    margin-top: 2px;
+    color: var(--unity-colors-default-text-hover);
+}

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TitleDrawer-Attribute-Styles.uss
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TitleDrawer-Attribute-Styles.uss
@@ -1,11 +1,11 @@
-Label.alchemy-attribute-title_drawer-title {
+.title-attribute__title {
     -unity-font-style: bold;
     padding-left: 3px;
     margin-top: 4px;
     margin-bottom: -2px;
 }
 
-Label.alchemy-attribute-title_drawer-subtitle {
+.title-attribute__subtitle {
     font-size: 10px;
     padding-left: 4.5px;
     margin-top: 2px;

--- a/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TitleDrawer-Attribute-Styles.uss.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Resources/Elements/TitleDrawer-Attribute-Styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2eb60c0e86a6794b9424ba71fd90dbb
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0


### PR DESCRIPTION
Hi there, I've gone ahead and moved all the inline styles into their own stylesheets. This way you should find it easier to modify and customize inspector elements. 

I also fixed the foldout insets inside of group boxes, and also the Horizontal Group label issue.