### PR TITLE
Fix: error on PropertyField that has no ObjectField child

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
@@ -147,6 +147,7 @@ namespace Alchemy.Editor
             propertyField.RegisterValueChangeCallback(x =>
             {
                 var objectField = propertyField.Q<ObjectField>();
+                if (objectField == null) return;
                 objectField.objectType = type;
                 objectField.allowSceneObjects = !isAssetsOnly;
             });


### PR DESCRIPTION
<img width="1062" alt="Screenshot 2025-04-10 at 3 46 41 PM" src="https://github.com/user-attachments/assets/233f9c2d-ecbc-42fe-9cc7-b5b80968ef79" />

A ```PropertyField``` may not contain an ```ObjectField```, which in my case happens when I use ```CustomPropertyDrawer``` with no VisualElement implementation (and it defaults to creating an ```IMGUIContainer```.

I think users should migrate to VisualElement, with or without Alchemy (which also come with an alternative ```CustomAttributeDrawer```), but at the same time adding a null check doesn't hurt.