### PR TITLE
Optional Order parameter for GroupAttribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # DS_Store
 *.DS_Store
+
+# Covers JetBrains IDEs
+.idea

--- a/Alchemy/Assets/Alchemy/Editor/AlchemyEditorUtility.cs
+++ b/Alchemy/Assets/Alchemy/Editor/AlchemyEditorUtility.cs
@@ -25,6 +25,7 @@ namespace Alchemy.Editor
             var drawerType = FindGroupDrawerType(attribute);
             var drawer = (AlchemyGroupDrawer)Activator.CreateInstance(drawerType);
             drawer.SetUniqueId("AlchemyGroupId_" + targetType.FullName + "_" + attribute.GroupPath);
+            drawer.SetOrder(attribute.Order);
             return drawer;
         }
     }

--- a/Alchemy/Assets/Alchemy/Editor/AlchemyGroupDrawer.cs
+++ b/Alchemy/Assets/Alchemy/Editor/AlchemyGroupDrawer.cs
@@ -9,6 +9,16 @@ namespace Alchemy.Editor
     public abstract class AlchemyGroupDrawer
     {
         /// <summary>
+        /// ID used to identify the group.
+        /// </summary>
+        public string UniqueId => _uniqueId;
+        
+        /// <summary>
+        /// Drawing order
+        /// </summary>
+        public int Order => _order;
+        
+        /// <summary>
         /// Create a visual element that will be the root of the group.
         /// </summary>
         /// <param name="label">Label text</param>
@@ -20,16 +30,17 @@ namespace Alchemy.Editor
         /// <param name="attribute">Target attribute</param>
         public virtual VisualElement GetGroupElement(Attribute attribute) => null;
 
-        /// <summary>
-        /// ID used to identify the group.
-        /// </summary>
-        public string UniqueId => uniqueId;
-
-        string uniqueId;
+        private string _uniqueId;
+        private int _order;
 
         internal void SetUniqueId(string id)
         {
-            this.uniqueId = id;
+            _uniqueId = id;
+        }
+
+        internal void SetOrder(int order)
+        {
+            _order = order;
         }
     }
 }

--- a/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
@@ -44,6 +44,7 @@ namespace Alchemy.Editor
             public void Add(GroupNode node)
             {
                 children.Add(node);
+                children.Sort((a, b) => a.drawer.Order.CompareTo(b.drawer.Order));
                 node.Parent = this;
             }
 

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/GroupAttributes.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/GroupAttributes.cs
@@ -2,24 +2,24 @@ namespace Alchemy.Inspector
 {
     public sealed class GroupAttribute : PropertyGroupAttribute
     {
-        public GroupAttribute() : base() { }
-        public GroupAttribute(string groupPath) : base(groupPath) { }
+        public GroupAttribute(int order = 0) : base(order) { }
+        public GroupAttribute(string groupPath, int order = 0) : base(groupPath, order) { }
     }
 
     public sealed class BoxGroupAttribute : PropertyGroupAttribute
     {
-        public BoxGroupAttribute() : base() { }
-        public BoxGroupAttribute(string groupPath) : base(groupPath) { }
+        public BoxGroupAttribute(int order = 0) : base(order) { }
+        public BoxGroupAttribute(string groupPath, int order = 0) : base(groupPath, order) { }
     }
 
     public sealed class TabGroupAttribute : PropertyGroupAttribute
     {
-        public TabGroupAttribute(string tabName) : base()
+        public TabGroupAttribute(string tabName, int order = 0) : base(order)
         {
             TabName = tabName;
         }
 
-        public TabGroupAttribute(string groupPath, string tabName) : base(groupPath)
+        public TabGroupAttribute(string groupPath, string tabName, int order = 0) : base(groupPath, order)
         {
             TabName = tabName;
         }
@@ -29,19 +29,19 @@ namespace Alchemy.Inspector
 
     public sealed class FoldoutGroupAttribute : PropertyGroupAttribute
     {
-        public FoldoutGroupAttribute() : base() { }
-        public FoldoutGroupAttribute(string groupPath) : base(groupPath) { }
+        public FoldoutGroupAttribute(int order = 0) : base(order) { }
+        public FoldoutGroupAttribute(string groupPath, int order = 0) : base(groupPath, order) { }
     }
 
     public sealed class HorizontalGroupAttribute : PropertyGroupAttribute
     {
-        public HorizontalGroupAttribute() : base() { }
-        public HorizontalGroupAttribute(string groupPath) : base(groupPath) { }
+        public HorizontalGroupAttribute(int order = 0) : base(order) { }
+        public HorizontalGroupAttribute(string groupPath, int order = 0) : base(groupPath, order) { }
     }
 
     public sealed class InlineGroupAttribute : PropertyGroupAttribute
     {
-        public InlineGroupAttribute() : base() { }
-        public InlineGroupAttribute(string groupPath) : base(groupPath) { }
+        public InlineGroupAttribute(int order = 0) : base(order) { }
+        public InlineGroupAttribute(string groupPath, int order = 0) : base(groupPath, order) { }
     }
 }

--- a/Alchemy/Assets/Alchemy/Runtime/Inspector/PropertyGroupAttribute.cs
+++ b/Alchemy/Assets/Alchemy/Runtime/Inspector/PropertyGroupAttribute.cs
@@ -7,16 +7,20 @@ namespace Alchemy.Inspector
     /// </summary>
     public abstract class PropertyGroupAttribute : Attribute
     {
-        public PropertyGroupAttribute()
+        public PropertyGroupAttribute(int order = 0)
         {
             GroupPath = string.Empty;
+            Order = order;
         }
         
-        public PropertyGroupAttribute(string groupPath)
+        public PropertyGroupAttribute(string groupPath, int order = 0)
         {
             GroupPath = groupPath;
+            Order = order;
         }
-
+        
         public string GroupPath { get; }
+        
+        public int Order { get; }
     }
 }

--- a/Alchemy/Assets/Tests/GroupOrderTest.cs
+++ b/Alchemy/Assets/Tests/GroupOrderTest.cs
@@ -1,0 +1,41 @@
+using Alchemy.Inspector;
+using UnityEngine;
+
+public class GroupOrderTest : MonoBehaviour
+{
+    [Group("Group3", 30)]
+    [SerializeField]
+    private float _valueFloatGroup3;
+    
+    [Group("Group3", 30)]
+    [SerializeField]
+    private string _valueStringGroup3;
+    
+    [Group("Group2", 20)]
+    [SerializeField]
+    private string _valueStringGroup2;
+    
+    [Group("Group1", 10)]
+    [SerializeField]
+    private float _valueFloatGroup1;
+    
+    [Group("Group1", 10)]
+    [SerializeField]
+    private string _valueStringGroup1;
+    
+    [Group("Group2", 20)]
+    [SerializeField]
+    private float _valueFloatGroup2;
+    
+    [Group("Group3" , 30)]
+    [SerializeField]
+    private bool _valueBoolGroup3;
+    
+    [Group("Group2", 20)]
+    [SerializeField]
+    private bool _valueBoolGroup2;
+    
+    [Group("Group1", 10)]
+    [SerializeField]
+    private bool _valueBoolGroup1;
+}

--- a/Alchemy/Assets/Tests/GroupOrderTest.cs.meta
+++ b/Alchemy/Assets/Tests/GroupOrderTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fb7a64e5440e6847967067f376a2b47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR introduces an optional int order parameter to the existing GroupAttribute, allowing inspector fields to be grouped and drawn in a defined sequence. Previously, reflection order could lead to unpredictable group ordering when fields are spread across base and derived classes. 

Usage Example: 

``` C#
public class GroupOrderTest : MonoBehaviour
{
    [Group("Group3", 30)]
    [SerializeField]
    private float _valueFloatGroup3;
    
    [Group("Group3", 30)]
    [SerializeField]
    private string _valueStringGroup3;
    
    [Group("Group2", 20)]
    [SerializeField]
    private string _valueStringGroup2;
    
    [Group("Group1", 10)]
    [SerializeField]
    private float _valueFloatGroup1;
    
    [Group("Group1", 10)]
    [SerializeField]
    private string _valueStringGroup1;
    
    [Group("Group2", 20)]
    [SerializeField]
    private float _valueFloatGroup2;
    
    [Group("Group3" , 30)]
    [SerializeField]
    private bool _valueBoolGroup3;
    
    [Group("Group2", 20)]
    [SerializeField]
    private bool _valueBoolGroup2;
    
    [Group("Group1", 10)]
    [SerializeField]
    private bool _valueBoolGroup1;
}
```

Inspector: 
![image](https://github.com/user-attachments/assets/688832d4-718a-48d9-9184-04a6a9dab371)
