### PR TITLE
[Bugfix] AlchemyEditorWindow: Ensure SerializedDataModeController included

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
@@ -101,7 +101,10 @@ namespace Alchemy.Editor
                 foreach (var member in node.Members.OrderByAttributeThenByMemberType())
                 {
                     // Exclude if member has HideInInspector attribute
-                    if (member.HasCustomAttribute<HideInInspector>()) continue;
+                    // but not "m_SerializedDataModeController" on EditorWindow
+                    // (Unity added HideInInspector here in 2022.3.23f1)
+                    if (member.HasCustomAttribute<HideInInspector>() && member.Name != "m_SerializedDataModeController") 
+                        continue;
 
                     // Add default PropertyField if member has DisableAlchemyEditorAttribute
                     if (member.GetCustomAttribute<DisableAlchemyEditorAttribute>() != null)


### PR DESCRIPTION
In newer version of unity (2022.3.23+), `AlchemyEditorWindow` does not work correctly (including the example from the docs), no fields are actually rendered in the UI.

`AlchemyEditorWindow` example from docs:
![image](https://github.com/user-attachments/assets/4b81c268-b9d5-4765-a6b6-245f8d078b67)


It turns out in this version unity added a `[HideInInspector]` attribute to `m_SerializedDataModeController` on `EditorWindow`, causing Alchemy to skip over this entirely and for the EditorWindow functionality to not work properly. This PR simply excludes `m_SerializedDataModeController` from being skipped by the usual `HideInInspectorAttribute` check. Have also tested in Unity 6 and the fix works there too.