### PR TITLE
Update link to SerializeReference unity doc page

### DIFF
--- a/docs/articles/en/serialize-reference.md
+++ b/docs/articles/en/serialize-reference.md
@@ -37,4 +37,4 @@ public class SerializeReferenceExample : MonoBehaviour
 
 Interfaces and abstract classes are displayed as shown above, and you can select and create subclasses from the dropdown.
 
-For more information about SerializeReference serialization, please refer to [Unity's official documentation](https://docs.unity3d.com/2020.3/ScriptReference/SerializeReference.html).
+For more information about SerializeReference serialization, please refer to [Unity's official documentation](https://docs.unity3d.com/6000.1/Documentation/ScriptReference/SerializeReference.html).


### PR DESCRIPTION
The [old link](https://docs.unity3d.com/2020.3/ScriptReference/SerializeReference.html) doesn't work. Here's the [new one](https://docs.unity3d.com/6000.1/Documentation/ScriptReference/SerializeReference.html).