### PR TITLE
fix: recognize private [SerializeReference] fields as serialized members

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/InspectorHelper.cs
@@ -208,7 +208,7 @@ namespace Alchemy.Editor
                 case FieldInfo:
                 case PropertyInfo:
                     var isSerializedMember = false;
-                    if (memberInfo is FieldInfo f) isSerializedMember = f.IsPublic | f.HasCustomAttribute<SerializeField>();
+                    if (memberInfo is FieldInfo f) isSerializedMember = f.IsPublic | f.HasCustomAttribute<SerializeField>() | f.HasCustomAttribute<SerializeReference>();
                     else if (memberInfo is PropertyInfo p) isSerializedMember = p.HasCustomAttribute<SerializeField>();
 
                     if (isSerializedMember)


### PR DESCRIPTION
Fields marked with [SerializeReference] were previously ignored unless also marked with [SerializeField] or public. This change ensures they are treated as serialized members as unity not prohibit to have them.