### PR TITLE
Hierarchy Rendering Fix: Resolve Prefab Active Toggle / Expand Button Overlap

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Hierarchy/HierarchyToggleDrawer.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Hierarchy/HierarchyToggleDrawer.cs
@@ -21,7 +21,7 @@ namespace Alchemy.Editor
                 rect.x = rect.xMax - 2.7f;
                 rect.width = 16f;
 
-                if (IsPrefab(gameObject))
+                if (IsNewPrefabWorkflow() && IsPrefab(gameObject))
                     rect.x -= 16.7f;
 
                 var active = GUI.Toggle(rect, gameObject.activeSelf, string.Empty);
@@ -38,7 +38,7 @@ namespace Alchemy.Editor
                 var rect = selectionRect;
                 rect.x = rect.xMax - (settings.ShowHierarchyToggles ? 18.7f : 2.7f);
 
-                if (IsPrefab(gameObject))
+                if (IsNewPrefabWorkflow() && IsPrefab(gameObject))
                     rect.x -= 16.7f;
 
                 rect.y += 1f;
@@ -89,6 +89,14 @@ namespace Alchemy.Editor
                 return false;
             var prefabType = PrefabUtility.GetPrefabAssetType(gameObj);
             return prefabType != PrefabAssetType.NotAPrefab;
+        }
+        private static bool IsNewPrefabWorkflow()
+        {
+#if UNITY_2018_3_OR_NEWER
+            return true;
+#else
+            return false;
+#endif
         }
     }
 

--- a/Alchemy/Assets/Alchemy/Editor/Hierarchy/HierarchyToggleDrawer.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Hierarchy/HierarchyToggleDrawer.cs
@@ -21,6 +21,9 @@ namespace Alchemy.Editor
                 rect.x = rect.xMax - 2.7f;
                 rect.width = 16f;
 
+                if (IsPrefab(gameObject))
+                    rect.x -= 16.7f;
+
                 var active = GUI.Toggle(rect, gameObject.activeSelf, string.Empty);
                 if (active != gameObject.activeSelf)
                 {
@@ -34,6 +37,10 @@ namespace Alchemy.Editor
             {
                 var rect = selectionRect;
                 rect.x = rect.xMax - (settings.ShowHierarchyToggles ? 18.7f : 2.7f);
+
+                if (IsPrefab(gameObject))
+                    rect.x -= 16.7f;
+
                 rect.y += 1f;
                 rect.width = 14f;
                 rect.height = 14f;
@@ -75,6 +82,13 @@ namespace Alchemy.Editor
         {
             var property = component.GetType().GetProperty("enabled", typeof(bool));
             return (bool)(property?.GetValue(component, null) ?? true);
+        }
+        private static bool IsPrefab(GameObject gameObj)
+        {
+            if (gameObj == null)
+                return false;
+            var prefabType = PrefabUtility.GetPrefabAssetType(gameObj);
+            return prefabType != PrefabAssetType.NotAPrefab;
         }
     }
 


### PR DESCRIPTION
This PR improves Hierarchy usability with the following updates:

- Fixed overlapping between the Prefab’s Active Toggle and the Expand button

- No functional changes; only adjustments to rendering/visuals

Thank you for your review.