### PR TITLE
fix: persist [Button] foldout state across Inspector selection changes

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/MethodButton.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine.UIElements;
@@ -28,14 +29,22 @@ namespace Alchemy.Editor.Elements
             var box = new HelpBox();
             Add(box);
 
+            string parameterSignature = string.Join("_", parameters.Select(p => p.ParameterType.Name));
+            string configKey = $"{target.GetType().FullName}_{methodInfo.Name}_{parameterSignature}_MethodButton";
+            bool.TryParse(EditorUserSettings.GetConfigValue(configKey), out bool savedFoldoutValue);
+
             foldout = new Foldout()
             {
                 text = methodInfo.Name,
-                value = false,
+                value = savedFoldoutValue,
                 style = {
                     flexGrow = 1f
                 }
             };
+            foldout.RegisterValueChangedCallback(x =>
+            {
+                EditorUserSettings.SetConfigValue(configKey, x.newValue.ToString());
+            });
             InternalAPIHelper.SetAcceptClicksIfDisabled(
                 InternalAPIHelper.GetClickable(foldout.Q<Toggle>()), true
             );


### PR DESCRIPTION
## Summary
- [Button] attribute methods with parameters have a foldout toggle that always resets to collapsed when Inspector selection changes
- Persist the foldout open/close state using `EditorUserSettings`, consistent with the existing `FoldoutGroupDrawer` approach
- The config key includes the target type, method name, and parameter signature to avoid collisions with overloaded methods

## Test plan
- [ ] Add a MonoBehaviour with a `[Button]` method that has parameters
- [ ] Expand the foldout in the Inspector
- [ ] Select a different GameObject, then re-select the original
- [ ] Verify the foldout remains expanded
- [ ] Add overloaded `[Button]` methods and verify each foldout state is independent