### PR TITLE
test: Add roundtrip test for all supported types

### DIFF
--- a/Alchemy/Assets/Alchemy/Tests/Alchemy.Tests.asmdef
+++ b/Alchemy/Assets/Alchemy/Tests/Alchemy.Tests.asmdef
@@ -1,12 +1,11 @@
 {
-    "name": "Alchemy.Tests.EditMode.Serialization",
-    "rootNamespace": "Alchemy.Tests.EditMode.Serialization",
+    "name": "Alchemy.Tests",
+    "rootNamespace": "Alchemy.Tests",
     "references": [
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:2765e68924a08a94ea0ea66b31c0168f",
-        "GUID:88be65f96b86746888c927a5c8ff3534",
-        "GUID:8a3e0c0612e778141892f52e0c40c067"
+        "GUID:88be65f96b86746888c927a5c8ff3534"
     ],
     "includePlatforms": [
         "Editor"

--- a/Alchemy/Assets/Alchemy/Tests/Alchemy.Tests.asmdef.meta
+++ b/Alchemy/Assets/Alchemy/Tests/Alchemy.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8a3e0c0612e778141892f52e0c40c067
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/AnimationCurveTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/AnimationCurveTest.cs
@@ -1,6 +1,4 @@
 #if ALCHEMY_SUPPORT_SERIALIZATION
-using System.Collections.Generic;
-using Alchemy.Serialization.Internal;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -11,18 +9,29 @@ namespace Alchemy.Tests.EditMode.Serialization
         [Test]
         public void Test_RoundTrip_AnimationCurve()
         {
-            var objects = new List<Object>();
-            var before = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
-            var beforeJson = SerializationHelper.ToJson(before, objects);
-            var after = SerializationHelper.FromJson<AnimationCurve>(beforeJson, objects);
+            var before = new AnimationCurve(
+                new Keyframe(0.25f, 0.75f, -1.5f, 2.5f, 0.2f, 0.8f) { weightedMode = WeightedMode.Both },
+                new Keyframe(1.5f, -0.25f, 3.5f, -4.5f, 0.1f, 0.9f) { weightedMode = WeightedMode.Out })
+            {
+                preWrapMode = WrapMode.PingPong,
+                postWrapMode = WrapMode.Loop,
+            };
 
-            Assert.AreEqual(before, after);
+            var after = TestUtility.RoundTrip(before);
+
+            Assert.That(after, Is.Not.Null);
+            Assert.That(after.preWrapMode, Is.EqualTo(before.preWrapMode));
+            Assert.That(after.postWrapMode, Is.EqualTo(before.postWrapMode));
+            Assert.That(after.keys, Has.Length.EqualTo(before.keys.Length));
+            for (var i = 0; i < before.keys.Length; i++)
+            {
+                AssertKeyframe(after.keys[i], before.keys[i]);
+            }
         }
 
         [Test]
         public void Test_RoundTrip_Keyframe()
         {
-            var objects = new List<Object>();
             var before = new Keyframe(0.25f, 0.75f, -1.5f, 2.5f, 0.2f, 0.8f)
             {
                 weightedMode = WeightedMode.Both,
@@ -31,14 +40,28 @@ namespace Alchemy.Tests.EditMode.Serialization
 #pragma warning restore 618
             };
 
-            var json = SerializationHelper.ToJson(before, objects);
-            var after = SerializationHelper.FromJson<Keyframe>(json, objects);
+            var after = TestUtility.RoundTrip(before);
 
-            Assert.AreEqual(before.inWeight, after.inWeight);
-            Assert.AreEqual(before.outWeight, after.outWeight);
-            Assert.AreEqual(before.weightedMode, after.weightedMode);
+            AssertKeyframe(after, before);
+        }
+
+        [Test]
+        public void Test_RoundTrip_NullAnimationCurve()
+        {
+            Assert.That(TestUtility.RoundTrip<AnimationCurve>(null), Is.Null);
+        }
+
+        static void AssertKeyframe(Keyframe actual, Keyframe expected)
+        {
+            Assert.That(actual.time, Is.EqualTo(expected.time));
+            Assert.That(actual.value, Is.EqualTo(expected.value));
+            Assert.That(actual.inTangent, Is.EqualTo(expected.inTangent));
+            Assert.That(actual.outTangent, Is.EqualTo(expected.outTangent));
+            Assert.That(actual.inWeight, Is.EqualTo(expected.inWeight));
+            Assert.That(actual.outWeight, Is.EqualTo(expected.outWeight));
+            Assert.That(actual.weightedMode, Is.EqualTo(expected.weightedMode));
 #pragma warning disable 618
-            Assert.AreEqual(before.tangentMode, after.tangentMode);
+            Assert.That(actual.tangentMode, Is.EqualTo(expected.tangentMode));
 #pragma warning restore 618
         }
     }

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CollectionTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CollectionTest.cs
@@ -1,0 +1,79 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Alchemy.Tests.EditMode.Serialization
+{
+    public class CollectionTest
+    {
+        [Test]
+        public void Test_RoundTrip_Array()
+        {
+            var values = new[] { -1, 0, 42 };
+
+            CollectionAssert.AreEqual(values, TestUtility.RoundTrip(values));
+            CollectionAssert.IsEmpty(TestUtility.RoundTrip(System.Array.Empty<int>()));
+            Assert.That(TestUtility.RoundTrip<int[]>(null), Is.Null);
+        }
+
+        [Test]
+        public void Test_RoundTrip_List()
+        {
+            var values = new List<string> { "first", null, "third" };
+
+            CollectionAssert.AreEqual(values, TestUtility.RoundTrip(values));
+            CollectionAssert.IsEmpty(TestUtility.RoundTrip(new List<string>()));
+            Assert.That(TestUtility.RoundTrip<List<string>>(null), Is.Null);
+        }
+
+        [Test]
+        public void Test_RoundTrip_HashSet()
+        {
+            var values = new HashSet<int> { -1, 3, 8 };
+
+            CollectionAssert.AreEquivalent(values, TestUtility.RoundTrip(values));
+            CollectionAssert.IsEmpty(TestUtility.RoundTrip(new HashSet<int>()));
+            Assert.That(TestUtility.RoundTrip<HashSet<int>>(null), Is.Null);
+        }
+
+        [Test]
+        public void Test_RoundTrip_Dictionary()
+        {
+            var values = new Dictionary<string, int>
+            {
+                ["negative"] = -1,
+                ["positive"] = 42,
+            };
+
+            CollectionAssert.AreEquivalent(values, TestUtility.RoundTrip(values));
+            CollectionAssert.IsEmpty(TestUtility.RoundTrip(new Dictionary<string, int>()));
+            Assert.That(TestUtility.RoundTrip<Dictionary<string, int>>(null), Is.Null);
+        }
+
+        [Test]
+        public void Test_RoundTrip_ValueTuple()
+        {
+            var value = (Id: 42, Label: "answer", Position: new Vector3(1.25f, -2.5f, 5f));
+
+            Assert.That(TestUtility.RoundTrip(value), Is.EqualTo(value));
+        }
+
+        [Test]
+        public void Test_RoundTrip_NestedCollections()
+        {
+            var value = new Dictionary<string, List<(int Id, bool Enabled)>>
+            {
+                ["first"] = new List<(int, bool)> { (1, true), (2, false) },
+                ["empty"] = new List<(int, bool)>(),
+            };
+
+            var after = TestUtility.RoundTrip(value);
+
+            Assert.That(after.Keys, Is.EquivalentTo(value.Keys));
+            Assert.That(after["first"], Is.EqualTo(value["first"]));
+            CollectionAssert.IsEmpty(after["empty"]);
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CollectionTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CollectionTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d6040dea324242399cb8d07b08a7ce66

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CompositeTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CompositeTest.cs
@@ -1,0 +1,106 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using System;
+using System.Collections.Generic;
+using Alchemy.Serialization.Internal;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Alchemy.Tests.EditMode.Serialization
+{
+    [Serializable]
+    class SerializableClassData
+    {
+        public int id;
+        public string name;
+        public SerializableStructData nested;
+        public List<string> values;
+    }
+
+    [Serializable]
+    struct SerializableStructData
+    {
+        public bool enabled;
+        public Vector3 position;
+        public (int Min, int Max) range;
+        public double ratio;
+    }
+
+    public class CompositeTest
+    {
+        [Test]
+        public void Test_RoundTrip_ClassConsistingOfSupportedTypes()
+        {
+            var value = CreateClassData();
+
+            var after = TestUtility.RoundTrip(value);
+
+            AssertClassData(after, value);
+        }
+
+        [Test]
+        public void Test_RoundTrip_StructConsistingOfSupportedTypes()
+        {
+            var value = CreateStructData();
+
+            var after = TestUtility.RoundTrip(value);
+
+            Assert.That(after.enabled, Is.EqualTo(value.enabled));
+            Assert.That(after.position, Is.EqualTo(value.position));
+            Assert.That(after.range, Is.EqualTo(value.range));
+            Assert.That(after.ratio, Is.EqualTo(value.ratio));
+        }
+
+        [Test]
+        public void Test_FromJsonOverride_UpdatesExistingClass()
+        {
+            var objectReferences = new List<UnityEngine.Object>();
+            var expected = CreateClassData();
+            var json = SerializationHelper.ToJson(expected, objectReferences);
+            var actual = new SerializableClassData
+            {
+                id = -1,
+                name = "stale",
+                values = new List<string> { "stale" },
+            };
+
+            SerializationHelper.FromJsonOverride(json, ref actual, objectReferences);
+
+            AssertClassData(actual, expected);
+        }
+
+        static SerializableClassData CreateClassData()
+        {
+            return new SerializableClassData
+            {
+                id = 42,
+                name = "composite",
+                nested = CreateStructData(),
+                values = new List<string> { "one", "two" },
+            };
+        }
+
+        static SerializableStructData CreateStructData()
+        {
+            return new SerializableStructData
+            {
+                enabled = true,
+                position = new Vector3(1.25f, -2.5f, 5f),
+                range = (-10, 20),
+                ratio = -98765.5d,
+            };
+        }
+
+        static void AssertClassData(SerializableClassData actual, SerializableClassData expected)
+        {
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.id, Is.EqualTo(expected.id));
+            Assert.That(actual.name, Is.EqualTo(expected.name));
+            Assert.That(actual.nested.enabled, Is.EqualTo(expected.nested.enabled));
+            Assert.That(actual.nested.position, Is.EqualTo(expected.nested.position));
+            Assert.That(actual.nested.range, Is.EqualTo(expected.nested.range));
+            Assert.That(actual.nested.ratio, Is.EqualTo(expected.nested.ratio));
+            CollectionAssert.AreEqual(expected.values, actual.values);
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CompositeTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/CompositeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 264204118ebd4dce9e704a225962fc8d

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/GradientTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/GradientTest.cs
@@ -1,6 +1,4 @@
 #if ALCHEMY_SUPPORT_SERIALIZATION
-using System.Collections.Generic;
-using Alchemy.Serialization.Internal;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -11,15 +9,14 @@ namespace Alchemy.Tests.EditMode.Serialization
         [Test]
         public void Test_RoundTrip_Gradient()
         {
-            var objects = new List<Object>();
             var before = new Gradient
             {
-                colorKeys = new GradientColorKey[] { new(Color.white, 0f) },
-                alphaKeys = new GradientAlphaKey[] { new(0f, 1f), new(1f, 1f) },
-                mode = GradientMode.Blend,
+                colorKeys = new[] { new GradientColorKey(Color.red, 0f), new GradientColorKey(Color.blue, 1f) },
+                alphaKeys = new[] { new GradientAlphaKey(0.25f, 0f), new GradientAlphaKey(0.75f, 1f) },
+                mode = GradientMode.Fixed,
             };
-            var beforeJson = SerializationHelper.ToJson(before, objects);
-            var after = SerializationHelper.FromJson<Gradient>(beforeJson, objects);
+
+            var after = TestUtility.RoundTrip(before);
 
             Assert.AreEqual(before, after);
         }
@@ -27,10 +24,8 @@ namespace Alchemy.Tests.EditMode.Serialization
         [Test]
         public void Test_RoundTrip_GradientColorKey()
         {
-            var objects = new List<Object>();
             var before = new GradientColorKey { color = Color.black, time = 1f };
-            var beforeJson = SerializationHelper.ToJson(before, objects);
-            var after = SerializationHelper.FromJson<GradientColorKey>(beforeJson, objects);
+            var after = TestUtility.RoundTrip(before);
 
             Assert.AreEqual(before, after);
         }
@@ -38,10 +33,8 @@ namespace Alchemy.Tests.EditMode.Serialization
         [Test]
         public void Test_RoundTrip_GradientAlphaKey()
         {
-            var objects = new List<Object>();
             var before = new GradientAlphaKey { alpha = 0.5f, time = 1f };
-            var beforeJson = SerializationHelper.ToJson(before, objects);
-            var after = SerializationHelper.FromJson<GradientAlphaKey>(beforeJson, objects);
+            var after = TestUtility.RoundTrip(before);
 
             Assert.AreEqual(before, after);
         }
@@ -50,13 +43,24 @@ namespace Alchemy.Tests.EditMode.Serialization
         [Test]
         public void Test_RoundTrip_PreservesColorSpace()
         {
-            var objects = new List<Object>();
-            var beforeJson = SerializationHelper.ToJson(ColorSpace.Linear, objects);
-            var after = SerializationHelper.FromJson<ColorSpace>(beforeJson, objects);
+            var before = new Gradient
+            {
+                colorKeys = new[] { new GradientColorKey(Color.white, 0f) },
+                alphaKeys = new[] { new GradientAlphaKey(1f, 0f) },
+                colorSpace = ColorSpace.Linear,
+            };
 
-            Assert.AreEqual(ColorSpace.Linear, after);
+            var after = TestUtility.RoundTrip(before);
+
+            Assert.That(after.colorSpace, Is.EqualTo(ColorSpace.Linear));
         }
 #endif
+
+        [Test]
+        public void Test_RoundTrip_NullGradient()
+        {
+            Assert.That(TestUtility.RoundTrip<Gradient>(null), Is.Null);
+        }
     }
 }
 #endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/NullableTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/NullableTest.cs
@@ -1,0 +1,19 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Alchemy.Tests.EditMode.Serialization
+{
+    public class NullableTest
+    {
+        [Test]
+        public void Test_RoundTrip_Nullable()
+        {
+            Vector3? value = new Vector3(1.25f, -2.5f, 5f);
+
+            Assert.That(TestUtility.RoundTrip(value), Is.EqualTo(value));
+            Assert.That(TestUtility.RoundTrip<Vector3?>(null), Is.Null);
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/NullableTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/NullableTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a4b7b02acd34a85b961e3852b39389c

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/PrimitiveTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/PrimitiveTest.cs
@@ -1,0 +1,48 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using NUnit.Framework;
+
+namespace Alchemy.Tests.EditMode.Serialization
+{
+    public class PrimitiveTest
+    {
+        enum SignedEnum : long
+        {
+            Negative = -9876543210L,
+        }
+
+        [System.Flags]
+        enum FlagsEnum : uint
+        {
+            First = 1u << 3,
+            Second = 1u << 29,
+        }
+
+        [Test]
+        public void Test_RoundTrip_AllPrimitiveTypes()
+        {
+            Assert.That(TestUtility.RoundTrip((sbyte)-101), Is.EqualTo((sbyte)-101));
+            Assert.That(TestUtility.RoundTrip((byte)251), Is.EqualTo((byte)251));
+            Assert.That(TestUtility.RoundTrip((short)-30001), Is.EqualTo((short)-30001));
+            Assert.That(TestUtility.RoundTrip((ushort)60001), Is.EqualTo((ushort)60001));
+            Assert.That(TestUtility.RoundTrip(-2000000001), Is.EqualTo(-2000000001));
+            Assert.That(TestUtility.RoundTrip(4000000001u), Is.EqualTo(4000000001u));
+            Assert.That(TestUtility.RoundTrip(-900000000000000001L), Is.EqualTo(-900000000000000001L));
+            Assert.That(TestUtility.RoundTrip(18000000000000000001UL), Is.EqualTo(18000000000000000001UL));
+            Assert.That(TestUtility.RoundTrip(123.625f), Is.EqualTo(123.625f));
+            Assert.That(TestUtility.RoundTrip(-98765.5d), Is.EqualTo(-98765.5d));
+            Assert.That(TestUtility.RoundTrip(true), Is.True);
+            Assert.That(TestUtility.RoundTrip("Alchemy \"JSON\" \n 団結"), Is.EqualTo("Alchemy \"JSON\" \n 団結"));
+            Assert.That(TestUtility.RoundTrip<string>(null), Is.Null);
+        }
+
+        [Test]
+        public void Test_RoundTrip_EnumTypes()
+        {
+            Assert.That(TestUtility.RoundTrip(SignedEnum.Negative), Is.EqualTo(SignedEnum.Negative));
+            Assert.That(
+                TestUtility.RoundTrip(FlagsEnum.First | FlagsEnum.Second),
+                Is.EqualTo(FlagsEnum.First | FlagsEnum.Second));
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/PrimitiveTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/PrimitiveTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 134c270129974be68d13f888c0ee1095

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityObjectTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityObjectTest.cs
@@ -1,0 +1,79 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using System;
+using System.Collections.Generic;
+using Alchemy.Serialization.Internal;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Alchemy.Tests.EditMode.Serialization
+{
+    [Serializable]
+    class UnityObjectContainer
+    {
+        public Texture2D typedReference;
+        public Object baseReference;
+        public List<Object> references;
+    }
+
+    public class UnityObjectTest
+    {
+        [Test]
+        public void Test_RoundTrip_UnityObject()
+        {
+            var texture = new Texture2D(1, 1);
+            var objectReferences = new List<Object>();
+
+            try
+            {
+                var after = TestUtility.RoundTrip(texture, objectReferences);
+
+                Assert.That(after, Is.SameAs(texture));
+                Assert.That(objectReferences, Has.Count.EqualTo(1));
+                Assert.That(objectReferences[0], Is.SameAs(texture));
+            }
+            finally
+            {
+                Object.DestroyImmediate(texture);
+            }
+        }
+
+        [Test]
+        public void Test_RoundTrip_NestedUnityObjects_DeduplicatesReferenceList()
+        {
+            var texture = new Texture2D(1, 1);
+            var objectReferences = new List<Object>();
+            var value = new UnityObjectContainer
+            {
+                typedReference = texture,
+                baseReference = texture,
+                references = new List<Object> { texture, null, texture },
+            };
+
+            try
+            {
+                var after = TestUtility.RoundTrip(value, objectReferences);
+
+                Assert.That(after.typedReference, Is.SameAs(texture));
+                Assert.That(after.baseReference, Is.SameAs(texture));
+                Assert.That(after.references[0], Is.SameAs(texture));
+                Assert.That(after.references[1], Is.Null);
+                Assert.That(after.references[2], Is.SameAs(texture));
+                Assert.That(objectReferences, Has.Count.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(texture);
+            }
+        }
+
+        [Test]
+        public void Test_DeserializeUnityObject_InvalidReferenceIndex_ReturnsNull()
+        {
+            var after = SerializationHelper.FromJson<Texture2D>("100", new List<Object>());
+
+            Assert.That(after, Is.Null);
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityObjectTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityObjectTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bcbced25d18f4a88b91e920f9bbc5c5e

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityValueTypeTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityValueTypeTest.cs
@@ -1,0 +1,29 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Alchemy.Tests.EditMode.Serialization
+{
+    public class UnityValueTypeTest
+    {
+        [Test]
+        public void Test_RoundTrip_InspectorSupportedUnityValueTypes()
+        {
+            Assert.That(TestUtility.RoundTrip(new Vector2(1.25f, -2.5f)), Is.EqualTo(new Vector2(1.25f, -2.5f)));
+            Assert.That(TestUtility.RoundTrip(new Vector2Int(12, -25)), Is.EqualTo(new Vector2Int(12, -25)));
+            Assert.That(TestUtility.RoundTrip(new Vector3(1.25f, -2.5f, 5f)), Is.EqualTo(new Vector3(1.25f, -2.5f, 5f)));
+            Assert.That(TestUtility.RoundTrip(new Vector3Int(12, -25, 50)), Is.EqualTo(new Vector3Int(12, -25, 50)));
+            Assert.That(TestUtility.RoundTrip(new Vector4(1.25f, -2.5f, 5f, 10f)), Is.EqualTo(new Vector4(1.25f, -2.5f, 5f, 10f)));
+            Assert.That(TestUtility.RoundTrip(new Rect(1.25f, -2.5f, 5f, 10f)), Is.EqualTo(new Rect(1.25f, -2.5f, 5f, 10f)));
+            Assert.That(TestUtility.RoundTrip(new RectInt(12, -25, 50, 100)), Is.EqualTo(new RectInt(12, -25, 50, 100)));
+            Assert.That(
+                TestUtility.RoundTrip(new Bounds(new Vector3(1f, 2f, 3f), new Vector3(4f, 5f, 6f))),
+                Is.EqualTo(new Bounds(new Vector3(1f, 2f, 3f), new Vector3(4f, 5f, 6f))));
+            Assert.That(
+                TestUtility.RoundTrip(new BoundsInt(new Vector3Int(1, 2, 3), new Vector3Int(4, 5, 6))),
+                Is.EqualTo(new BoundsInt(new Vector3Int(1, 2, 3), new Vector3Int(4, 5, 6))));
+            Assert.That(TestUtility.RoundTrip(new Color(0.125f, 0.25f, 0.5f, 0.75f)), Is.EqualTo(new Color(0.125f, 0.25f, 0.5f, 0.75f)));
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityValueTypeTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/EditMode.Serialization/UnityValueTypeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 55e88edf408a40d0a3875652b6db05b9

--- a/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization.meta
+++ b/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5df5c0929c11ec54f81a398646e52971
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/Alchemy.Tests.PlayMode.Serialization.asmdef
+++ b/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/Alchemy.Tests.PlayMode.Serialization.asmdef
@@ -1,16 +1,13 @@
 {
-    "name": "Alchemy.Tests.EditMode.Serialization",
-    "rootNamespace": "Alchemy.Tests.EditMode.Serialization",
+    "name": "Alchemy.Tests.PlayMode.Serialization",
+    "rootNamespace": "Alchemy.Tests.PlayMode.Serialization",
     "references": [
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:2765e68924a08a94ea0ea66b31c0168f",
-        "GUID:88be65f96b86746888c927a5c8ff3534",
-        "GUID:8a3e0c0612e778141892f52e0c40c067"
+        "GUID:88be65f96b86746888c927a5c8ff3534"
     ],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": true,

--- a/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/Alchemy.Tests.PlayMode.Serialization.asmdef.meta
+++ b/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/Alchemy.Tests.PlayMode.Serialization.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: df0270b6321417248b4400eed7c02004
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/GeneratedTest.cs
+++ b/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/GeneratedTest.cs
@@ -1,0 +1,168 @@
+#if ALCHEMY_SUPPORT_SERIALIZATION
+using System;
+using System.Collections.Generic;
+using Alchemy.Serialization;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Alchemy.Tests.PlayMode.Serialization
+{
+    [Serializable]
+    class GeneratedClassData
+    {
+        public int id;
+        public string name;
+        public GeneratedStructData nested;
+        public List<string> values;
+    }
+
+    [Serializable]
+    struct GeneratedStructData
+    {
+        public bool enabled;
+        public Vector3 position;
+        public (int Min, int Max) range;
+        public double ratio;
+    }
+
+    [AlchemySerialize]
+    partial class GeneratedSerializationTarget : IAlchemySerializationCallbackReceiver
+    {
+        [AlchemySerializeField, NonSerialized] public int primitive;
+        [AlchemySerializeField, NonSerialized] public Texture2D unityObject;
+        [AlchemySerializeField, NonSerialized] public AnimationCurve animationCurve;
+        [AlchemySerializeField, NonSerialized] public Gradient gradient;
+        [AlchemySerializeField, NonSerialized] public int[] array;
+        [AlchemySerializeField, NonSerialized] public List<string> list;
+        [AlchemySerializeField, NonSerialized] public HashSet<int> hashSet;
+        [AlchemySerializeField, NonSerialized] public Dictionary<string, Texture2D> dictionary;
+        [AlchemySerializeField, NonSerialized] public (int Id, string Label) valueTuple;
+        [AlchemySerializeField, NonSerialized] public Vector3? nullable;
+        [AlchemySerializeField, NonSerialized] public GeneratedClassData classData;
+        [AlchemySerializeField, NonSerialized] public GeneratedStructData structData;
+
+        public int beforeSerializeCallbackCount;
+        public int afterDeserializeCallbackCount;
+        public int primitiveObservedAfterDeserialize;
+
+        void IAlchemySerializationCallbackReceiver.OnBeforeSerialize()
+        {
+            beforeSerializeCallbackCount++;
+        }
+
+        void IAlchemySerializationCallbackReceiver.OnAfterDeserialize()
+        {
+            afterDeserializeCallbackCount++;
+            primitiveObservedAfterDeserialize = primitive;
+        }
+    }
+
+    public class GeneratedTest
+    {
+        [Test]
+        public void Test_GeneratedCallbacks_RoundTrip_AllSupportedTypeCategories()
+        {
+            var texture = new Texture2D(1, 1);
+            var target = new GeneratedSerializationTarget
+            {
+                primitive = 42,
+                unityObject = texture,
+                animationCurve = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f),
+                gradient = new Gradient
+                {
+                    colorKeys = new[] { new GradientColorKey(Color.red, 0f), new GradientColorKey(Color.blue, 1f) },
+                    alphaKeys = new[] { new GradientAlphaKey(0.25f, 0f), new GradientAlphaKey(0.75f, 1f) },
+                    mode = GradientMode.Fixed,
+                },
+                array = new[] { 1, 2, 3 },
+                list = new List<string> { "one", "two" },
+                hashSet = new HashSet<int> { 3, 5, 8 },
+                dictionary = new Dictionary<string, Texture2D> { ["texture"] = texture },
+                valueTuple = (42, "answer"),
+                nullable = new Vector3(1.25f, -2.5f, 5f),
+                classData = CreateClassData(),
+                structData = CreateStructData(),
+            };
+
+            try
+            {
+                var callback = (ISerializationCallbackReceiver)target;
+                callback.OnBeforeSerialize();
+
+                target.primitive = default;
+                target.unityObject = null;
+                target.animationCurve = null;
+                target.gradient = null;
+                target.array = null;
+                target.list = null;
+                target.hashSet = null;
+                target.dictionary = null;
+                target.valueTuple = default;
+                target.nullable = null;
+                target.classData = null;
+                target.structData = default;
+
+                callback.OnAfterDeserialize();
+
+                Assert.That(target.beforeSerializeCallbackCount, Is.EqualTo(1));
+                Assert.That(target.afterDeserializeCallbackCount, Is.EqualTo(1));
+                Assert.That(target.primitiveObservedAfterDeserialize, Is.EqualTo(42));
+                Assert.That(target.primitive, Is.EqualTo(42));
+                Assert.That(target.unityObject, Is.SameAs(texture));
+                Assert.That(target.animationCurve, Is.EqualTo(AnimationCurve.EaseInOut(0f, 0f, 1f, 1f)));
+                Assert.That(target.gradient.mode, Is.EqualTo(GradientMode.Fixed));
+                CollectionAssert.AreEqual(new[] { 1, 2, 3 }, target.array);
+                CollectionAssert.AreEqual(new[] { "one", "two" }, target.list);
+                CollectionAssert.AreEquivalent(new[] { 3, 5, 8 }, target.hashSet);
+                Assert.That(target.dictionary["texture"], Is.SameAs(texture));
+                Assert.That(target.valueTuple, Is.EqualTo((42, "answer")));
+                Assert.That(target.nullable, Is.EqualTo(new Vector3(1.25f, -2.5f, 5f)));
+                AssertClassData(target.classData, CreateClassData());
+                Assert.That(target.structData.enabled, Is.True);
+                Assert.That(target.structData.position, Is.EqualTo(new Vector3(1.25f, -2.5f, 5f)));
+                Assert.That(target.structData.range, Is.EqualTo((-10, 20)));
+                Assert.That(target.structData.ratio, Is.EqualTo(-98765.5d));
+            }
+            finally
+            {
+                Object.DestroyImmediate(texture);
+            }
+        }
+
+        static GeneratedClassData CreateClassData()
+        {
+            return new GeneratedClassData
+            {
+                id = 42,
+                name = "generated",
+                nested = CreateStructData(),
+                values = new List<string> { "one", "two" },
+            };
+        }
+
+        static GeneratedStructData CreateStructData()
+        {
+            return new GeneratedStructData
+            {
+                enabled = true,
+                position = new Vector3(1.25f, -2.5f, 5f),
+                range = (-10, 20),
+                ratio = -98765.5d,
+            };
+        }
+
+        static void AssertClassData(GeneratedClassData actual, GeneratedClassData expected)
+        {
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.id, Is.EqualTo(expected.id));
+            Assert.That(actual.name, Is.EqualTo(expected.name));
+            Assert.That(actual.nested.enabled, Is.EqualTo(expected.nested.enabled));
+            Assert.That(actual.nested.position, Is.EqualTo(expected.nested.position));
+            Assert.That(actual.nested.range, Is.EqualTo(expected.nested.range));
+            Assert.That(actual.nested.ratio, Is.EqualTo(expected.nested.ratio));
+            CollectionAssert.AreEqual(expected.values, actual.values);
+        }
+    }
+}
+#endif

--- a/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/GeneratedTest.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/PlayMode.Serialization/GeneratedTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bb2af62da4447faa22954b1871941ae

--- a/Alchemy/Assets/Alchemy/Tests/TestUtility.cs
+++ b/Alchemy/Assets/Alchemy/Tests/TestUtility.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Alchemy.Serialization.Internal;
+using UnityEngine;
+
+namespace Alchemy.Tests
+{
+    public static class TestUtility
+    {
+#if ALCHEMY_SUPPORT_SERIALIZATION
+        public static T RoundTrip<T>(T value, IList<Object> objectReferences = null)
+        {
+            objectReferences ??= new List<Object>();
+            var json = SerializationHelper.ToJson(value, objectReferences);
+            return SerializationHelper.FromJson<T>(json, objectReferences);
+        }
+#endif
+    }
+}

--- a/Alchemy/Assets/Alchemy/Tests/TestUtility.cs.meta
+++ b/Alchemy/Assets/Alchemy/Tests/TestUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80582b528c27458884d0d83cbaef1fad


### PR DESCRIPTION
- Add EditMode round-trip tests for supported primitives, collections, nullable values, composite types, Unity objects, and Unity value types