### PR TITLE
Fix reflection field editor crashes

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -187,7 +187,7 @@ namespace Alchemy.Editor.Drawers
 
         public override void OnCreateElement()
         {
-            if (SerializedProperty.propertyType != SerializedPropertyType.ObjectReference) return;
+            if (SerializedProperty == null || SerializedProperty.propertyType != SerializedPropertyType.ObjectReference) return;
 
             var message = ((RequiredAttribute)Attribute).Message ?? ObjectNames.NicifyVariableName(SerializedProperty.displayName) + " is required.";
             helpBox = new HelpBox(message, HelpBoxMessageType.Error);
@@ -211,6 +211,8 @@ namespace Alchemy.Editor.Drawers
 
         public override void OnCreateElement()
         {
+            if (SerializedProperty == null) return;
+
             var message = ((ValidateInputAttribute)Attribute).Message ?? ObjectNames.NicifyVariableName(SerializedProperty.displayName) + " is not valid.";
             helpBox = new HelpBox(message, HelpBoxMessageType.Error);
 

--- a/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Elements/GenericField.cs
@@ -172,7 +172,11 @@ namespace Alchemy.Editor.Elements
             else if (type == typeof(char))
             {
                 var charField = new TextField(label, 1, false, false, default) { value = obj.ToString() };
-                charField.RegisterValueChangedCallback(x => OnValueChanged?.Invoke(x.newValue[0]));
+                charField.RegisterValueChangedCallback(x =>
+                {
+                    if (string.IsNullOrEmpty(x.newValue)) return;
+                    OnValueChanged?.Invoke(x.newValue[0]);
+                });
                 Add(charField);
             }
             else if (type.IsEnum)

--- a/Alchemy/Assets/Alchemy/Editor/TrackSerializedObjectAttributeDrawer.cs
+++ b/Alchemy/Assets/Alchemy/Editor/TrackSerializedObjectAttributeDrawer.cs
@@ -6,10 +6,13 @@ namespace Alchemy.Editor.Drawers
     {
         public override void OnCreateElement()
         {
-            TargetElement.TrackSerializedObjectValue(SerializedObject, x =>
+            if (SerializedObject != null)
             {
-                OnInspectorChanged();
-            });
+                TargetElement.TrackSerializedObjectValue(SerializedObject, x =>
+                {
+                    OnInspectorChanged();
+                });
+            }
 
             OnInspectorChanged();
             TargetElement.schedule.Execute(() => OnInspectorChanged());

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/ClassFieldTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/ClassFieldTest.cs
@@ -1,0 +1,72 @@
+using Alchemy.Editor.Elements;
+using Alchemy.Inspector;
+using NUnit.Framework;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Alchemy.Tests.EditorUI.PlayModeInEditor
+{
+    public class ClassFieldTest
+    {
+        sealed class ConditionalTarget
+        {
+            public bool show;
+
+            [ShowIf(nameof(show))]
+            public int showIf;
+
+            public bool hide = true;
+
+            [HideIf(nameof(hide))]
+            public int hideIf;
+        }
+
+        sealed class RequiredTarget
+        {
+            [Required]
+            public GameObject value;
+        }
+
+        sealed class ValidateInputTarget
+        {
+            [ValidateInput(nameof(IsValid))]
+            public int value;
+
+            public bool IsValid(int input) => input >= 0;
+        }
+
+        [Test]
+        public void Test_ConditionalAttributesDoNotRequireSerializedObject()
+        {
+            var target = new ConditionalTarget();
+            var field = new ClassField(target, target.GetType(), "Target");
+
+            var showIfField = EditorTestUtility.QueryRequired<ReflectionField>(
+                field,
+                element => element.Q<IntegerField>()?.label == "Show If");
+            var hideIfField = EditorTestUtility.QueryRequired<ReflectionField>(
+                field,
+                element => element.Q<IntegerField>()?.label == "Hide If");
+
+            Assert.That(showIfField.style.display.value, Is.EqualTo(DisplayStyle.None));
+            Assert.That(hideIfField.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [Test]
+        public void Test_RequiredAttributeDoesNotRequireSerializedProperty()
+        {
+            var target = new RequiredTarget();
+
+            Assert.DoesNotThrow(() => new ClassField(target, target.GetType(), "Target"));
+        }
+
+        [Test]
+        public void Test_ValidateInputAttributeDoesNotRequireSerializedProperty()
+        {
+            var target = new ValidateInputTarget();
+
+            Assert.DoesNotThrow(() => new ClassField(target, target.GetType(), "Target"));
+        }
+    }
+}

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/ClassFieldTest.cs.meta
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/ClassFieldTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e49f58565184f10b0330a71a1c79c82

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/GenericFieldTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/GenericFieldTest.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using Alchemy.Editor.Elements;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Alchemy.Tests.EditorUI.PlayModeInEditor
+{
+    public class GenericFieldTest
+    {
+        [UnityTest]
+        public IEnumerator Test_CharInputCanBeCleared()
+        {
+            var field = new GenericField('x', typeof(char), "Character");
+            var changedValue = 'x';
+            field.OnValueChanged += value => changedValue = (char)value;
+
+            var window = EditorTestUtility.ShowInWindow(field);
+            try
+            {
+                yield return null;
+
+                var textField = EditorTestUtility.QueryRequired<TextField>(field);
+                Assert.DoesNotThrow(() => textField.value = string.Empty);
+                Assert.That(changedValue, Is.EqualTo('x'));
+
+                textField.value = "y";
+                Assert.That(changedValue, Is.EqualTo('y'));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(window);
+            }
+        }
+    }
+}

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/GenericFieldTest.cs.meta
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/PlayModeInEditor/GenericFieldTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b58746a57e024c54b0553848889eadca


### PR DESCRIPTION
- Prevent `char` fields from indexing an empty value when cleared.
- Guard attribute drawers when reflection fields have no serialized context.
