### PR TITLE
Remove Unity 2022 from test lanes

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ dotnet run --project tests/UnityTestRunner --configuration Release -- --treenode
 dotnet run --project tests/UnityTestRunner --configuration Release -- --treenode-filter "/*/Alchemy.UnityTestRunner/Unity*EditorCaptureTests/*"
 ```
 
-Unity versions are registered explicitly in `UnityTestRunner/UnityVersionTests.cs`. Each version has an EditMode test and a PlayMode test.
+The active test lanes are Unity 6000.0, 6000.3, 6000.5, and 6000.7, registered explicitly in `UnityTestRunner/UnityVersionTests.cs`. Each version has an EditMode test and a PlayMode test.
 
 Unity Editor logs are stored under each version project's `Logs/UnityTestRunner/<run-id>` directory. Unity logs and NUnit reports are attached to their TUnit test, and warning-or-higher entries are written to stderr.
 

--- a/tests/UnityTestRunner/UnityEditorLifecycle.cs
+++ b/tests/UnityTestRunner/UnityEditorLifecycle.cs
@@ -14,11 +14,9 @@ internal sealed class UnityEditorLifecycle(UnityCli unityCli)
         Action<string> writeProgress,
         CancellationToken cancellationToken)
     {
-        var connectedEditor = project.MajorVersion >= 6000
-            ? await unityCli.FindConnectedEditorAsync(
-                project,
-                cancellationToken)
-            : null;
+        var connectedEditor = await unityCli.FindConnectedEditorAsync(
+            project,
+            cancellationToken);
         if (connectedEditor is not null)
         {
             writeProgress(

--- a/tests/UnityTestRunner/UnityTest.cs
+++ b/tests/UnityTestRunner/UnityTest.cs
@@ -103,42 +103,19 @@ internal static class UnityTest
 
         var reportPath = Path.Combine(context.LogDirectory, $"{mode}.xml");
         var editorLogPath = Path.Combine(context.LogDirectory, $"{mode}.log");
-        var cliLogPath = project.MajorVersion >= 6000
-            ? string.Empty
-            : Path.Combine(context.LogDirectory, $"{mode}.cli.log");
 
         WriteProgress(project, $"{mode}: running...");
 
         try
         {
-            if (project.MajorVersion >= 6000)
-            {
-                await RunUnityProcessModeAsync(
-                    project,
-                    context,
-                    mode,
-                    reportPath,
-                    editorLogPath,
-                    cancellationToken);
-                ValidateReport(project, mode, reportPath);
-                return;
-            }
-
-            var result = await RunUnityAsync(
+            await RunUnityProcessModeAsync(
                 project,
-                context.EditorPath,
+                context,
                 mode,
                 reportPath,
                 editorLogPath,
                 cancellationToken);
             ValidateReport(project, mode, reportPath);
-            if (result.ExitCode != 0)
-            {
-                throw new UnityExecutionException(
-                    $"Unity {project.EditorVersion} {mode} exited with code " +
-                    $"{result.ExitCode} despite producing a passing report." +
-                    FormatProcessDiagnostic(result));
-            }
         }
         finally
         {
@@ -146,10 +123,9 @@ internal static class UnityTest
             {
                 context.RefreshLogPath,
                 editorLogPath,
-                cliLogPath,
                 reportPath,
             };
-            WriteLogDiagnostics(project, [editorLogPath, cliLogPath]);
+            WriteLogDiagnostics(project, [editorLogPath]);
             AttachArtifacts(artifacts);
         }
     }
@@ -289,47 +265,6 @@ internal static class UnityTest
         }
     }
 
-    private static async Task<ProcessResult> RunUnityAsync(
-        UnityProject project,
-        string editorPath,
-        TestMode mode,
-        string reportPath,
-        string editorLogPath,
-        CancellationToken cancellationToken)
-    {
-        var fileName = UnityEditorLifecycle.GetEditorExecutable(editorPath);
-        if (!File.Exists(fileName))
-        {
-            throw new UnityUnavailableException(
-                $"The installed Unity editor executable does not exist: {fileName}");
-        }
-
-        var arguments = BuildBatchModeArguments(
-            project,
-            mode,
-            reportPath,
-            editorLogPath);
-        var workingDirectory = project.ProjectPath;
-
-        try
-        {
-            var result = await ProcessRunner.RunAsync(
-                new ProcessSpec(
-                    fileName,
-                    arguments,
-                    workingDirectory,
-                    TerminateDescendantsOnExit: true),
-                cancellationToken);
-            return result;
-        }
-        catch (ProcessExecutionException exception)
-        {
-            throw new UnityExecutionException(
-                $"Could not start Unity {project.EditorVersion} for {mode}.",
-                exception);
-        }
-    }
-
     private static IReadOnlyList<string> BuildLibraryWarmupArguments(
         UnityProject project,
         string logPath)
@@ -346,31 +281,6 @@ internal static class UnityTest
             "-logFile",
             logPath,
         ];
-    }
-
-    private static IReadOnlyList<string> BuildBatchModeArguments(
-        UnityProject project,
-        TestMode mode,
-        string reportPath,
-        string logPath)
-    {
-        var command = mode == TestMode.EditMode
-            ? "Alchemy.Tests.TestCommands.RunAllEditModeTests"
-            : "Alchemy.Tests.TestCommands.RunAllPlayModeTests";
-        var arguments = CreateTestArguments(mode);
-        arguments.AddRange(
-        [
-            "-projectPath",
-            ".",
-            "-executeMethod",
-            command,
-            "-testResults",
-            reportPath,
-            "--auto-quit",
-            "-logFile",
-            logPath,
-        ]);
-        return arguments;
     }
 
     private static List<string> CreateTestArguments(TestMode mode)
@@ -418,16 +328,6 @@ internal static class UnityTest
                $"{summary.Failed} failed, " +
                $"{summary.Inconclusive} inconclusive, " +
                $"{summary.Skipped} skipped";
-    }
-
-    private static string FormatProcessDiagnostic(ProcessResult result)
-    {
-        var diagnostic = string.IsNullOrWhiteSpace(result.StandardError)
-            ? result.StandardOutput
-            : result.StandardError;
-        return string.IsNullOrWhiteSpace(diagnostic)
-            ? string.Empty
-            : $"{Environment.NewLine}{diagnostic.Trim()}";
     }
 
     private static void WriteProgress(UnityProject project, string message)

--- a/tests/UnityTestRunner/UnityVersionTests.cs
+++ b/tests/UnityTestRunner/UnityVersionTests.cs
@@ -2,24 +2,6 @@ using TUnit.Core;
 
 namespace Alchemy.UnityTestRunner;
 
-public sealed class Unity2022_3UnitTests
-{
-    private static readonly UnityProject Project =
-        UnityProject.Locate("../versions/Unity2022.3");
-
-    [Before(HookType.Class)]
-    public static Task Refresh(CancellationToken cancellationToken) =>
-        UnityTest.RefreshAsync(Project, cancellationToken);
-
-    [Test]
-    public Task EditMode(CancellationToken cancellationToken) =>
-        UnityTest.RunAsync(Project, TestMode.EditMode, cancellationToken);
-
-    [Test]
-    public Task PlayMode(CancellationToken cancellationToken) =>
-        UnityTest.RunAsync(Project, TestMode.PlayMode, cancellationToken);
-}
-
 public sealed class Unity6000_0UnitTests
 {
     private static readonly UnityProject Project =

--- a/tests/versions/Unity6000.3/ProjectSettings/ProjectSettings.asset
+++ b/tests/versions/Unity6000.3/ProjectSettings/ProjectSettings.asset
@@ -298,7 +298,99 @@ PlayerSettings:
   AndroidReportGooglePlayAppDependencies: 1
   androidSymbolsSizeThreshold: 800
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
   m_BuildTargetBatching: []
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []

--- a/tests/versions/Unity6000.7/ProjectSettings/ProjectAuditorSettings.asset
+++ b/tests/versions/Unity6000.7/ProjectSettings/ProjectAuditorSettings.asset
@@ -19,12 +19,8 @@ MonoBehaviour:
     - PlatformGroup:
         m_String: Unknown
       m_SerializedParams:
-      - Key: SpriteAtlasEmptySpaceLimit
-        Value: 50
       - Key: StreamingAssetsFolderSizeLimit
         Value: 50
-      - Key: TextureStreamingMipmapsSizeLimit
-        Value: 4000
       - Key: StreamingClipThresholdBytes
         Value: 218294
       - Key: LongDecompressedClipThresholdBytes
@@ -33,4 +29,8 @@ MonoBehaviour:
         Value: 204800
       - Key: LoadInBackGroundClipSizeThresholdBytes
         Value: 204800
+      - Key: TextureStreamingMipmapsSizeLimit
+        Value: 4000
+      - Key: SpriteAtlasEmptySpaceLimit
+        Value: 50
     CurrentParamsIndex: 0


### PR DESCRIPTION
Since the Unity CLI does not support Unity 2022, a separate system is required to run this version. For maintainability reasons, this PR removes the e2e tests for Unity 2022.