### PR TITLE
Preview and List inspector optimizations

### DIFF
--- a/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
+++ b/Alchemy/Assets/Alchemy/Editor/BuiltinAttributeDrawers.cs
@@ -354,6 +354,7 @@ namespace Alchemy.Editor.Drawers
     public sealed class PreviewDrawer : TrackSerializedObjectAttributeDrawer
     {
         private Image image;
+        private PreviewImageUpdater previewUpdater;
         private const float BorderWidth = 1f;
         private static readonly Color borderColor = new Color(0f, 0f, 0f, 0.3f);
 
@@ -393,23 +394,14 @@ namespace Alchemy.Editor.Drawers
 
             var parent = TargetElement.parent;
             parent.Insert(parent.IndexOf(TargetElement) + 1, image);
+            previewUpdater = new PreviewImageUpdater(TargetElement, image);
 
             base.OnCreateElement();
         }
 
         protected override void OnInspectorChanged()
         {
-            if (SerializedProperty.objectReferenceValue == null)
-            {
-                image.image = null;
-                return;
-            }
-
-            TargetElement.schedule.Execute(() =>
-            {
-                var texture = AssetPreview.GetAssetPreview(SerializedProperty.objectReferenceValue);
-                image.image = texture;
-            }).Until(() => image.image != null);
+            previewUpdater?.Update(SerializedProperty.objectReferenceValue);
         }
     }
 

--- a/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/GUIHelper.cs
@@ -157,6 +157,9 @@ namespace Alchemy.Editor
 
         public static void ScheduleAdjustLabelWidth(VisualElement element)
         {
+            EventCallback<GeometryChangedEvent> onGeometryChanged = null;
+            VisualElement registeredTree = null;
+
             void Adjust(VisualElement visualElement)
             {
                 var label = element.Q<Label>();
@@ -165,13 +168,37 @@ namespace Alchemy.Editor
                 label.style.width = CalculateLabelWidth(element, visualElement);
             }
 
-            // Adjust label width
-            element.schedule.Execute(() =>
+            void Unregister()
             {
-                var visualTree = element.panel.visualTree;
-                visualTree.RegisterCallback<GeometryChangedEvent>(x => Adjust(visualTree));
+                if (registeredTree != null && onGeometryChanged != null)
+                {
+                    registeredTree.UnregisterCallback(onGeometryChanged);
+                }
+
+                registeredTree = null;
+                onGeometryChanged = null;
+            }
+
+            void Register(IPanel panel)
+            {
+                var visualTree = panel?.visualTree;
+                if (visualTree == null) return;
+                if (registeredTree == visualTree) return;
+
+                Unregister();
+                registeredTree = visualTree;
+                onGeometryChanged = _ => Adjust(visualTree);
+                visualTree.RegisterCallback(onGeometryChanged);
                 Adjust(visualTree);
-            });
+            }
+
+            element.RegisterCallback<AttachToPanelEvent>(evt => Register(evt.destinationPanel));
+            element.RegisterCallback<DetachFromPanelEvent>(_ => Unregister());
+
+            if (element.panel != null)
+            {
+                Register(element.panel);
+            }
         }
 
         public static IMGUIContainer CreateLine(Color color, float height)

--- a/Alchemy/Assets/Alchemy/Editor/Internal/PreviewImageUpdater.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/PreviewImageUpdater.cs
@@ -1,0 +1,91 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Alchemy.Editor
+{
+    internal sealed class PreviewImageUpdater
+    {
+        public const int DefaultMaxAttempts = 64;
+
+        readonly VisualElement scheduler;
+        readonly Image image;
+        readonly Func<UnityEngine.Object, Texture> getPreview;
+        readonly int maxAttempts;
+
+        IVisualElementScheduledItem job;
+        UnityEngine.Object target;
+        int attempts;
+
+        public PreviewImageUpdater(
+            VisualElement scheduler,
+            Image image,
+            Func<UnityEngine.Object, Texture> getPreview = null,
+            int maxAttempts = DefaultMaxAttempts)
+        {
+            this.scheduler = scheduler;
+            this.image = image;
+            this.getPreview = getPreview ?? AssetPreview.GetAssetPreview;
+            this.maxAttempts = maxAttempts;
+        }
+
+        public bool HasActiveJob => job != null;
+        public int Attempts => attempts;
+        public UnityEngine.Object Target => target;
+
+        public void Update(UnityEngine.Object reference)
+        {
+            if (reference == null)
+            {
+                Stop();
+                image.image = null;
+                target = null;
+                attempts = 0;
+                return;
+            }
+
+            if (reference != target)
+            {
+                Stop();
+                image.image = null;
+                target = reference;
+                attempts = 0;
+            }
+
+            if (image.image != null) return;
+            if (job != null) return;
+            if (attempts >= maxAttempts) return;
+
+            var captured = reference;
+            job = scheduler.schedule.Execute(() =>
+            {
+                if (image.panel == null)
+                {
+                    Stop();
+                    return;
+                }
+
+                if (captured != target) return;
+
+                attempts++;
+                image.image = getPreview(captured);
+                if (image.image != null || attempts >= maxAttempts)
+                {
+                    job = null;
+                }
+            }).Until(() =>
+                image.panel == null
+                || image.image != null
+                || attempts >= maxAttempts
+                || captured != target
+            );
+        }
+
+        public void Stop()
+        {
+            job?.Pause();
+            job = null;
+        }
+    }
+}

--- a/Alchemy/Assets/Alchemy/Editor/Internal/PreviewImageUpdater.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/PreviewImageUpdater.cs
@@ -53,10 +53,12 @@ namespace Alchemy.Editor
                 attempts = 0;
             }
 
-            if (image.image != null) return;
             if (job != null) return;
-            if (attempts >= maxAttempts) return;
 
+            // Bound each job, but let later Inspector notifications retry or refresh
+            // the same reference. Keep its current image until a replacement is ready.
+            attempts = 0;
+            var completed = false;
             var captured = reference;
             job = scheduler.schedule.Execute(() =>
             {
@@ -69,15 +71,20 @@ namespace Alchemy.Editor
                 if (captured != target) return;
 
                 attempts++;
-                image.image = getPreview(captured);
-                if (image.image != null || attempts >= maxAttempts)
+                var preview = getPreview(captured);
+                if (preview != null)
+                {
+                    image.image = preview;
+                }
+
+                completed = preview != null || attempts >= maxAttempts;
+                if (completed)
                 {
                     job = null;
                 }
             }).Until(() =>
                 image.panel == null
-                || image.image != null
-                || attempts >= maxAttempts
+                || completed
                 || captured != target
             );
         }

--- a/Alchemy/Assets/Alchemy/Editor/Internal/PreviewImageUpdater.cs.meta
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/PreviewImageUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e8c1a7b5d924f6e9c4a2b8d0f1e6a73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Alchemy/Assets/Alchemy/Editor/Internal/SerializedPropertyExtensions.cs
+++ b/Alchemy/Assets/Alchemy/Editor/Internal/SerializedPropertyExtensions.cs
@@ -179,26 +179,21 @@ namespace Alchemy.Editor
 
         static object GetElementAtOrDefault(object arrayOrListObj, int index)
         {
+            if (arrayOrListObj is IList valueList && index >= 0 && index < valueList.Count)
+            {
+                return valueList[index];
+            }
+
             if (arrayOrListObj is IEnumerable<object> referenceEnumerable)
             {
                 return referenceEnumerable.ElementAtOrDefault(index);
             }
 
-            if (arrayOrListObj is IList valueList)
+            if (arrayOrListObj is IList fallbackList)
             {
-                object result;
-                if (index < 0 || index >= valueList.Count)
-                {
-                    Type listType = valueList.GetType();
-                    Type elementType = listType.IsArray ? listType.GetElementType() : listType.GetGenericArguments()[0];
-                    result = Activator.CreateInstance(elementType);
-                }
-                else
-                {
-                    result = valueList[index];
-                }
-
-                return result;
+                Type listType = fallbackList.GetType();
+                Type elementType = listType.IsArray ? listType.GetElementType() : listType.GetGenericArguments()[0];
+                return Activator.CreateInstance(elementType);
             }
 
             throw new ArgumentException($"Can't parse {arrayOrListObj.GetType()} as Array or List");

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/EditModeEditorTestUtility.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/EditModeEditorTestUtility.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Alchemy.Tests.EditorUI.EditMode
+{
+    internal static class EditModeEditorTestUtility
+    {
+        sealed class TestWindow : EditorWindow { }
+
+        public static EditorWindow ShowInWindow(VisualElement content)
+        {
+            var window = ScriptableObject.CreateInstance<TestWindow>();
+            window.position = new Rect(0f, 0f, 640f, 480f);
+            window.rootVisualElement.Add(content);
+            window.Show();
+            return window;
+        }
+    }
+}

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/EditModeEditorTestUtility.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/EditModeEditorTestUtility.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -15,6 +18,17 @@ namespace Alchemy.Tests.EditorUI.EditMode
             window.rootVisualElement.Add(content);
             window.Show();
             return window;
+        }
+
+        public static IEnumerable WaitUntil(Func<bool> condition, float timeoutSeconds = 2f)
+        {
+            var deadline = EditorApplication.timeSinceStartup + timeoutSeconds;
+            while (!condition())
+            {
+                Assert.That(EditorApplication.timeSinceStartup, Is.LessThan(deadline),
+                    "Timed out waiting for the Editor UI to update.");
+                yield return null;
+            }
         }
     }
 }

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/EditModeEditorTestUtility.cs.meta
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/EditModeEditorTestUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d4f2a6c1e9b47a3b5c0d7e8f1a2b3c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/GUIHelperTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/GUIHelperTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Alchemy.Editor;
 using NUnit.Framework;
 #if !UNITY_2022_1_OR_NEWER
@@ -21,19 +22,40 @@ namespace Alchemy.Tests.EditorUI.EditMode
             try
             {
                 GUIHelper.ScheduleAdjustLabelWidth(field);
-                yield return null;
+                var visualTree = field.panel.visualTree;
+                window.position = new Rect(0f, 0f, 800f, 480f);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() =>
+                    Mathf.Abs(visualTree.resolvedStyle.width - 800f) < 1f))
+                    yield return wait;
 
                 var label = field.Q<Label>();
                 Assert.That(label, Is.Not.Null);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() =>
+                    Mathf.Abs(label.resolvedStyle.width - GUIHelper.CalculateLabelWidth(field, visualTree)) < 1f))
+                    yield return wait;
                 Assert.That(label.resolvedStyle.width, Is.GreaterThan(0f));
+                var originalWidth = label.resolvedStyle.width;
 
                 field.RemoveFromHierarchy();
-                yield return null;
+                window.position = new Rect(0f, 0f, 500f, 480f);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() =>
+                    Mathf.Abs(visualTree.resolvedStyle.width - 500f) < 1f))
+                    yield return wait;
 
                 window.rootVisualElement.Add(field);
-                yield return null;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() =>
+                    label.resolvedStyle.width < originalWidth))
+                    yield return wait;
 
-                Assert.That(label.resolvedStyle.width, Is.GreaterThan(0f));
+                Assert.That(label.resolvedStyle.width, Is.LessThan(originalWidth));
+                Assert.That(label.resolvedStyle.width,
+                    Is.EqualTo(GUIHelper.CalculateLabelWidth(field, field.panel.visualTree)).Within(1f));
+
+                window.position = new Rect(0f, 0f, 600f, 480f);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() =>
+                    Mathf.Abs(visualTree.resolvedStyle.width - 600f) < 1f &&
+                    Mathf.Abs(label.resolvedStyle.width - GUIHelper.CalculateLabelWidth(field, visualTree)) < 1f))
+                    yield return wait;
             }
             finally
             {
@@ -45,23 +67,17 @@ namespace Alchemy.Tests.EditorUI.EditMode
         public IEnumerator ScheduleAdjustLabelWidth_DoesNotKeepDetachedElementAlive()
         {
             var window = EditModeEditorTestUtility.ShowInWindow(new VisualElement());
-            WeakReference weak;
             try
             {
+                var weak = CreateDetachedField(window.rootVisualElement);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() =>
                 {
-                    var field = new IntegerField("Value") { value = 1 };
-                    window.rootVisualElement.Add(field);
-                    GUIHelper.ScheduleAdjustLabelWidth(field);
-                    yield return null;
-                    weak = new WeakReference(field);
-                    field.RemoveFromHierarchy();
-                }
-
-                yield return null;
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
-                yield return null;
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    return !weak.IsAlive;
+                }))
+                    yield return wait;
 
                 Assert.That(weak.IsAlive, Is.False);
             }
@@ -69,6 +85,16 @@ namespace Alchemy.Tests.EditorUI.EditMode
             {
                 UnityEngine.Object.DestroyImmediate(window);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference CreateDetachedField(VisualElement root)
+        {
+            var field = new IntegerField("Value") { value = 1 };
+            root.Add(field);
+            GUIHelper.ScheduleAdjustLabelWidth(field);
+            field.RemoveFromHierarchy();
+            return new WeakReference(field);
         }
     }
 }

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/GUIHelperTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/GUIHelperTest.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections;
+using Alchemy.Editor;
+using NUnit.Framework;
+#if !UNITY_2022_1_OR_NEWER
+using UnityEditor.UIElements;
+#endif
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Alchemy.Tests.EditorUI.EditMode
+{
+    public class GUIHelperTest
+    {
+        [UnityTest]
+        public IEnumerator ScheduleAdjustLabelWidth_ReattachStillUpdatesLabel()
+        {
+            var field = new IntegerField("Value") { value = 1 };
+            var window = EditModeEditorTestUtility.ShowInWindow(field);
+            try
+            {
+                GUIHelper.ScheduleAdjustLabelWidth(field);
+                yield return null;
+
+                var label = field.Q<Label>();
+                Assert.That(label, Is.Not.Null);
+                Assert.That(label.resolvedStyle.width, Is.GreaterThan(0f));
+
+                field.RemoveFromHierarchy();
+                yield return null;
+
+                window.rootVisualElement.Add(field);
+                yield return null;
+
+                Assert.That(label.resolvedStyle.width, Is.GreaterThan(0f));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(window);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator ScheduleAdjustLabelWidth_DoesNotKeepDetachedElementAlive()
+        {
+            var window = EditModeEditorTestUtility.ShowInWindow(new VisualElement());
+            WeakReference weak;
+            try
+            {
+                {
+                    var field = new IntegerField("Value") { value = 1 };
+                    window.rootVisualElement.Add(field);
+                    GUIHelper.ScheduleAdjustLabelWidth(field);
+                    yield return null;
+                    weak = new WeakReference(field);
+                    field.RemoveFromHierarchy();
+                }
+
+                yield return null;
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                yield return null;
+
+                Assert.That(weak.IsAlive, Is.False);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(window);
+            }
+        }
+    }
+}

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/GUIHelperTest.cs.meta
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/GUIHelperTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c2a5e7d1f4b48c0a3d6e8f1b2c4d5e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/PreviewImageUpdaterTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/PreviewImageUpdaterTest.cs
@@ -1,0 +1,192 @@
+using System.Collections;
+using Alchemy.Editor;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Alchemy.Tests.EditorUI.EditMode
+{
+    public class PreviewImageUpdaterTest
+    {
+        [UnityTest]
+        public IEnumerator Update_StartsOnlyOneJobForTheSameReference()
+        {
+            var image = new Image();
+            var host = new VisualElement();
+            host.Add(image);
+            var window = EditModeEditorTestUtility.ShowInWindow(host);
+            var calls = 0;
+            try
+            {
+                yield return null;
+
+                var updater = new PreviewImageUpdater(host, image, _ =>
+                {
+                    calls++;
+                    return null;
+                }, maxAttempts: 16);
+                var reference = Texture2D.whiteTexture;
+
+                updater.Update(reference);
+                updater.Update(reference);
+                updater.Update(reference);
+                Assert.That(updater.HasActiveJob, Is.True);
+
+                yield return null;
+                var callsAfterFirstFrame = calls;
+                yield return null;
+
+                Assert.That(updater.HasActiveJob, Is.True);
+                Assert.That(callsAfterFirstFrame, Is.GreaterThan(0));
+                Assert.That(calls - callsAfterFirstFrame, Is.EqualTo(1));
+
+                updater.Stop();
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Update_StopsJobWhenReferenceBecomesNull()
+        {
+            var image = new Image();
+            var host = new VisualElement();
+            host.Add(image);
+            var window = EditModeEditorTestUtility.ShowInWindow(host);
+            var calls = 0;
+            try
+            {
+                yield return null;
+
+                var updater = new PreviewImageUpdater(host, image, _ =>
+                {
+                    calls++;
+                    return null;
+                }, maxAttempts: 16);
+
+                updater.Update(Texture2D.whiteTexture);
+                yield return null;
+                Assert.That(updater.HasActiveJob, Is.True);
+                Assert.That(calls, Is.GreaterThan(0));
+
+                updater.Update(null);
+                Assert.That(image.image, Is.Null);
+                Assert.That(updater.HasActiveJob, Is.False);
+                Assert.That(updater.Target, Is.Null);
+
+                var callsAfterStop = calls;
+                yield return null;
+                yield return null;
+                Assert.That(calls, Is.EqualTo(callsAfterStop));
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Update_RestartsWhenReferenceChanges()
+        {
+            var image = new Image();
+            var host = new VisualElement();
+            host.Add(image);
+            var window = EditModeEditorTestUtility.ShowInWindow(host);
+            UnityEngine.Object lastRequested = null;
+            try
+            {
+                yield return null;
+
+                var updater = new PreviewImageUpdater(host, image, value =>
+                {
+                    lastRequested = value;
+                    return null;
+                }, maxAttempts: 16);
+
+                updater.Update(Texture2D.whiteTexture);
+                yield return null;
+                Assert.That(lastRequested, Is.SameAs(Texture2D.whiteTexture));
+
+                updater.Update(Texture2D.blackTexture);
+                Assert.That(image.image, Is.Null);
+                Assert.That(updater.Target, Is.SameAs(Texture2D.blackTexture));
+                Assert.That(updater.HasActiveJob, Is.True);
+                Assert.That(updater.Attempts, Is.EqualTo(0));
+
+                yield return null;
+                Assert.That(lastRequested, Is.SameAs(Texture2D.blackTexture));
+                updater.Stop();
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Update_StopsAfterMaxAttempts()
+        {
+            var image = new Image();
+            var host = new VisualElement();
+            host.Add(image);
+            var window = EditModeEditorTestUtility.ShowInWindow(host);
+            const int maxAttempts = 3;
+            try
+            {
+                yield return null;
+
+                var updater = new PreviewImageUpdater(host, image, _ => null, maxAttempts);
+                updater.Update(Texture2D.whiteTexture);
+
+                for (var i = 0; i < maxAttempts + 2; i++)
+                {
+                    yield return null;
+                }
+
+                Assert.That(updater.HasActiveJob, Is.False);
+                Assert.That(updater.Attempts, Is.EqualTo(maxAttempts));
+                Assert.That(image.image, Is.Null);
+
+                updater.Update(Texture2D.whiteTexture);
+                yield return null;
+                Assert.That(updater.HasActiveJob, Is.False);
+                Assert.That(updater.Attempts, Is.EqualTo(maxAttempts));
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Update_StopsWhenPreviewBecomesAvailable()
+        {
+            var image = new Image();
+            var host = new VisualElement();
+            host.Add(image);
+            var window = EditModeEditorTestUtility.ShowInWindow(host);
+            Texture preview = null;
+            try
+            {
+                yield return null;
+
+                var updater = new PreviewImageUpdater(host, image, _ => preview, maxAttempts: 8);
+                updater.Update(Texture2D.whiteTexture);
+                yield return null;
+                Assert.That(updater.HasActiveJob, Is.True);
+
+                preview = Texture2D.whiteTexture;
+                yield return null;
+                Assert.That(image.image, Is.SameAs(Texture2D.whiteTexture));
+                Assert.That(updater.HasActiveJob, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+    }
+}

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/PreviewImageUpdaterTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/PreviewImageUpdaterTest.cs
@@ -25,7 +25,7 @@ namespace Alchemy.Tests.EditorUI.EditMode
                 {
                     calls++;
                     return null;
-                }, maxAttempts: 16);
+                }, maxAttempts: 3);
                 var reference = Texture2D.whiteTexture;
 
                 updater.Update(reference);
@@ -33,13 +33,10 @@ namespace Alchemy.Tests.EditorUI.EditMode
                 updater.Update(reference);
                 Assert.That(updater.HasActiveJob, Is.True);
 
-                yield return null;
-                var callsAfterFirstFrame = calls;
-                yield return null;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => !updater.HasActiveJob))
+                    yield return wait;
 
-                Assert.That(updater.HasActiveJob, Is.True);
-                Assert.That(callsAfterFirstFrame, Is.GreaterThan(0));
-                Assert.That(calls - callsAfterFirstFrame, Is.EqualTo(1));
+                Assert.That(calls, Is.EqualTo(3));
 
                 updater.Stop();
             }
@@ -68,7 +65,8 @@ namespace Alchemy.Tests.EditorUI.EditMode
                 }, maxAttempts: 16);
 
                 updater.Update(Texture2D.whiteTexture);
-                yield return null;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => calls > 0))
+                    yield return wait;
                 Assert.That(updater.HasActiveJob, Is.True);
                 Assert.That(calls, Is.GreaterThan(0));
 
@@ -107,7 +105,8 @@ namespace Alchemy.Tests.EditorUI.EditMode
                 }, maxAttempts: 16);
 
                 updater.Update(Texture2D.whiteTexture);
-                yield return null;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => lastRequested == Texture2D.whiteTexture))
+                    yield return wait;
                 Assert.That(lastRequested, Is.SameAs(Texture2D.whiteTexture));
 
                 updater.Update(Texture2D.blackTexture);
@@ -116,7 +115,8 @@ namespace Alchemy.Tests.EditorUI.EditMode
                 Assert.That(updater.HasActiveJob, Is.True);
                 Assert.That(updater.Attempts, Is.EqualTo(0));
 
-                yield return null;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => lastRequested == Texture2D.blackTexture))
+                    yield return wait;
                 Assert.That(lastRequested, Is.SameAs(Texture2D.blackTexture));
                 updater.Stop();
             }
@@ -127,33 +127,79 @@ namespace Alchemy.Tests.EditorUI.EditMode
         }
 
         [UnityTest]
-        public IEnumerator Update_StopsAfterMaxAttempts()
+        public IEnumerator Update_StopsAfterMaxAttemptsAndRetriesOnLaterNotification()
         {
             var image = new Image();
             var host = new VisualElement();
             host.Add(image);
             var window = EditModeEditorTestUtility.ShowInWindow(host);
             const int maxAttempts = 3;
+            Texture preview = null;
             try
             {
                 yield return null;
 
-                var updater = new PreviewImageUpdater(host, image, _ => null, maxAttempts);
+                var updater = new PreviewImageUpdater(host, image, _ => preview, maxAttempts);
                 updater.Update(Texture2D.whiteTexture);
 
-                for (var i = 0; i < maxAttempts + 2; i++)
-                {
-                    yield return null;
-                }
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => !updater.HasActiveJob))
+                    yield return wait;
 
                 Assert.That(updater.HasActiveJob, Is.False);
                 Assert.That(updater.Attempts, Is.EqualTo(maxAttempts));
                 Assert.That(image.image, Is.Null);
 
-                updater.Update(Texture2D.whiteTexture);
                 yield return null;
                 Assert.That(updater.HasActiveJob, Is.False);
                 Assert.That(updater.Attempts, Is.EqualTo(maxAttempts));
+
+                preview = Texture2D.whiteTexture;
+                updater.Update(Texture2D.whiteTexture);
+                Assert.That(updater.HasActiveJob, Is.True);
+                Assert.That(updater.Attempts, Is.Zero);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => !updater.HasActiveJob))
+                    yield return wait;
+                Assert.That(image.image, Is.SameAs(preview));
+                Assert.That(updater.HasActiveJob, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(window);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Update_RefreshesSameReferenceWhileKeepingPreviousImage()
+        {
+            var image = new Image();
+            var host = new VisualElement();
+            host.Add(image);
+            var window = EditModeEditorTestUtility.ShowInWindow(host);
+            Texture preview = Texture2D.whiteTexture;
+            try
+            {
+                yield return null;
+
+                var updater = new PreviewImageUpdater(host, image, _ => preview, maxAttempts: 8);
+                var reference = Texture2D.grayTexture;
+                updater.Update(reference);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => !updater.HasActiveJob))
+                    yield return wait;
+                Assert.That(image.image, Is.SameAs(Texture2D.whiteTexture));
+                Assert.That(updater.HasActiveJob, Is.False);
+
+                preview = null;
+                updater.Update(reference);
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => updater.Attempts > 0))
+                    yield return wait;
+                Assert.That(updater.HasActiveJob, Is.True);
+                Assert.That(image.image, Is.SameAs(Texture2D.whiteTexture));
+
+                preview = Texture2D.blackTexture;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => !updater.HasActiveJob))
+                    yield return wait;
+                Assert.That(image.image, Is.SameAs(Texture2D.blackTexture));
+                Assert.That(updater.HasActiveJob, Is.False);
             }
             finally
             {
@@ -179,7 +225,8 @@ namespace Alchemy.Tests.EditorUI.EditMode
                 Assert.That(updater.HasActiveJob, Is.True);
 
                 preview = Texture2D.whiteTexture;
-                yield return null;
+                foreach (var wait in EditModeEditorTestUtility.WaitUntil(() => !updater.HasActiveJob))
+                    yield return wait;
                 Assert.That(image.image, Is.SameAs(Texture2D.whiteTexture));
                 Assert.That(updater.HasActiveJob, Is.False);
             }

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/PreviewImageUpdaterTest.cs.meta
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/PreviewImageUpdaterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b6e4c8a0d3f45a79e2c5d8f0a1b3c6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/SerializedPropertyExtensionsTest.cs
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/SerializedPropertyExtensionsTest.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using Alchemy.Editor;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace Alchemy.Tests.EditorUI.EditMode
+{
+    public class SerializedPropertyExtensionsTest
+    {
+        [Serializable]
+        public class NestedItem
+        {
+            public int value;
+        }
+
+        class ListHost : ScriptableObject
+        {
+            public List<NestedItem> items;
+        }
+
+        class ArrayHost : ScriptableObject
+        {
+            public NestedItem[] items;
+        }
+
+        [Test]
+        public void GetValue_ListOfClass_ReadsIndexedElement()
+        {
+            var host = ScriptableObject.CreateInstance<ListHost>();
+            try
+            {
+                host.items = new List<NestedItem>(50);
+                for (var i = 0; i < 50; i++)
+                {
+                    host.items.Add(new NestedItem { value = i });
+                }
+
+                var serializedObject = new SerializedObject(host);
+                var property = serializedObject.FindProperty("items.Array.data[42].value");
+
+                Assert.That(property, Is.Not.Null);
+                Assert.That(property.GetValue<int>(), Is.EqualTo(42));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(host);
+            }
+        }
+
+        [Test]
+        public void GetValue_ArrayOfClass_ReadsIndexedElement()
+        {
+            var host = ScriptableObject.CreateInstance<ArrayHost>();
+            try
+            {
+                host.items = new NestedItem[20];
+                for (var i = 0; i < host.items.Length; i++)
+                {
+                    host.items[i] = new NestedItem { value = i * 3 };
+                }
+
+                var serializedObject = new SerializedObject(host);
+                var property = serializedObject.FindProperty("items.Array.data[17].value");
+
+                Assert.That(property, Is.Not.Null);
+                Assert.That(property.GetValue<int>(), Is.EqualTo(51));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(host);
+            }
+        }
+
+        [Test]
+        public void GetValue_ListOfClass_ReadsFirstAndLastElements()
+        {
+            var host = ScriptableObject.CreateInstance<ListHost>();
+            try
+            {
+                host.items = new List<NestedItem>
+                {
+                    new NestedItem { value = 11 },
+                    new NestedItem { value = 22 },
+                    new NestedItem { value = 33 },
+                };
+
+                var serializedObject = new SerializedObject(host);
+                Assert.That(
+                    serializedObject.FindProperty("items.Array.data[0].value").GetValue<int>(),
+                    Is.EqualTo(11));
+                Assert.That(
+                    serializedObject.FindProperty("items.Array.data[2].value").GetValue<int>(),
+                    Is.EqualTo(33));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(host);
+            }
+        }
+    }
+}

--- a/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/SerializedPropertyExtensionsTest.cs.meta
+++ b/tests/Alchemy.Tests/Assets/Alchemy.Tests.EditorUI/EditMode/SerializedPropertyExtensionsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e7a1c9b2d5f40a8b6c3e0f1a2d4b5c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/UnityTestRunner/UnityTest.cs
+++ b/tests/UnityTestRunner/UnityTest.cs
@@ -219,7 +219,8 @@ internal static class UnityTest
         var command = mode == TestMode.EditMode
             ? "Alchemy.Tests.TestCommands.RunAllEditModeTests"
             : "Alchemy.Tests.TestCommands.RunAllPlayModeTests";
-        var arguments = CreateTestArguments(mode);
+        // Both modes include UI tests that need a graphics device for EditorWindow.Show().
+        var arguments = new List<string> { "-batchmode" };
         arguments.AddRange(
         [
             "-automated",
@@ -281,19 +282,6 @@ internal static class UnityTest
             "-logFile",
             logPath,
         ];
-    }
-
-    private static List<string> CreateTestArguments(TestMode mode)
-    {
-        var arguments = new List<string> { "-batchmode" };
-        // The editor-only tests are safe to run headlessly; PlayMode also hosts
-        // the UI tests and must initialize a graphics device for EditorWindow.Show().
-        if (mode == TestMode.EditMode)
-        {
-            arguments.Add("-nographics");
-        }
-
-        return arguments;
     }
 
     private static string CreateLogDirectory(UnityProject project)


### PR DESCRIPTION
These changes stop the Inspector from stacking extra work on every edit. Preview fields keep one AssetPreview poll and cancel it on null, reference change, or a retry limit. Label-width callbacks now unregister on detach, so rebuilt UI is not kept alive by panel resize events.

Large collections also get cheaper access. Serialized list rows use the indexer instead of walking from the start, Hierarchy icons run only on Repaint, HashMap cancel no longer rebuilds every row, Unity object references use a dictionary while keeping the same index format, and array edits copy only the changed element.

The saved JSON shape and public Inspector behavior stay the same. HashMap virtualization and per-field serialize updates were left for later.